### PR TITLE
Add publish workflow in Github Actions

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,33 @@
+name: publish-snapshot
+on:
+  workflow_dispatch:
+    branches:
+      - 'main'
+jobs:
+  java-gradle-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 8
+          cache: gradle
+      - name: Run Gradle Build
+        run: ./gradlew build
+  publish-snapshot-jar:
+    runs-on: ubuntu-latest
+    needs: java-gradle-build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 8
+          cache: gradle
+      - name: Publish Snapshot
+        env:
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          CLIENT_GPG_PASSPHRASE: ${{ secrets.CLIENT_GPG_PASSPHRASE }}
+          CLIENT_GPG_KEY: ${{ secrets.CLIENT_GPG_KEY }}
+        run: ./gradlew publish


### PR DESCRIPTION
The workflow is added as "`on: workflow_dispatch`" for now and can be triggered on the Github UI manually.
Once we test it a few times we can automate it either by scheduling it with a cron in Github Actions or by triggering it from Buildkite