### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/release-java-client.yml
+++ b/.github/workflows/release-java-client.yml
@@ -1,0 +1,41 @@
+name: release-java-client
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release Version'
+        required: true
+    branches:
+      - 'main'
+jobs:
+  java-gradle-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 8
+          cache: gradle
+      - name: Run Gradle Build
+        run: ./gradlew build
+  publish-jar:
+    runs-on: ubuntu-latest
+    needs: java-gradle-build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 8
+          cache: gradle
+      - name: Publish Release Version
+        if: "${{ github.event.inputs.version != '' }}"
+        env:
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          CLIENT_GPG_PASSPHRASE: ${{ secrets.CLIENT_GPG_PASSPHRASE }}
+          CLIENT_GPG_KEY: ${{ secrets.CLIENT_GPG_KEY }}
+        run: ./gradlew -Pversion=${{inputs.version}} publish
+      - name: Handle Empty Version
+        if: "${{ github.event.inputs.version == '' }}"
+        run: echo Please specify a non empty release version


### PR DESCRIPTION
Add a separate workflow to cut a public (non-snapshot) release by specifying the version through Github Actions