### PR TITLE
Make Java Client a slim jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,11 +36,6 @@ dependencies {
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.3.1'
 }
 
-//Package JAR with dependencies
-jar {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
-
 //Run tests during build and output status
 test {
     useJUnit()

--- a/build.gradle
+++ b/build.gradle
@@ -39,12 +39,6 @@ dependencies {
 //Package JAR with dependencies
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    // @see https://youtrack.jetbrains.com/issue/KT-25709
-    exclude("**/*.kotlin_metadata")
-    exclude("**/*.kotlin_builtins")
 }
 
 //Run tests during build and output status

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ jar {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
+    // @see https://youtrack.jetbrains.com/issue/KT-25709
+    exclude("**/*.kotlin_metadata")
+    exclude("**/*.kotlin_builtins")
 }
 
 //Run tests during build and output status

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.2.0-SNAPSHOT
+version=0.3.0-SNAPSHOT
 ossrh.username=tecton-team


### PR DESCRIPTION
# What

The Java Client JAR is currently being distributed as a fat jar and includes all dependencies. To make it easier for both us and customers to manage third party dependencies, we will instead package the client as a slim jar and let customers add dependencies declared in the pom file to their classpath

# Testing

Tested locally with both Java and Kotlin Demo projects