### PR TITLE
Remove leading backslash from url path

### DIFF
--- a/src/main/java/ai/tecton/client/request/GetFeatureServiceMetadataRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeatureServiceMetadataRequest.java
@@ -15,7 +15,7 @@ import com.squareup.moshi.Moshi;
 public class GetFeatureServiceMetadataRequest extends AbstractTectonRequest {
 
   private static final TectonHttpClient.HttpMethod method = TectonHttpClient.HttpMethod.POST;
-  private static final String ENDPOINT = "/api/v1/feature-service/metadata";
+  private static final String ENDPOINT = "api/v1/feature-service/metadata";
   private static final String DEFAULT_WORKSPACE = "prod";
   private JsonAdapter<GetFeatureServiceMetadataJson> jsonAdapter;
 

--- a/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
@@ -44,7 +44,7 @@ public class GetFeaturesBatchRequest {
   private List<? extends AbstractGetFeaturesRequest> requestList;
   private final int microBatchSize;
   private final Duration timeout;
-  private static final String BATCH_ENDPOINT = "/api/v1/feature-service/get-features-batch";
+  private static final String BATCH_ENDPOINT = "api/v1/feature-service/get-features-batch";
   private static JsonAdapter<GetFeaturesMicroBatchRequest.GetFeaturesRequestBatchJson> jsonAdapter =
       null;
   private String endpoint;

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
  */
 public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
 
-  static final String ENDPOINT = "/api/v1/feature-service/get-features";
+  static final String ENDPOINT = "api/v1/feature-service/get-features";
   private final JsonAdapter<GetFeaturesRequestJson> jsonAdapter;
   private final GetFeaturesRequestData getFeaturesRequestData;
 

--- a/src/test/java/ai/tecton/client/request/GetFeatureServiceMetadataRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeatureServiceMetadataRequestTest.java
@@ -9,7 +9,7 @@ public class GetFeatureServiceMetadataRequestTest {
 
   private static final String TEST_WORKSPACENAME = "testWorkspaceName";
   private static final String TEST_FEATURESERVICE_NAME = "testFSName";
-  private static final String ENDPOINT = "/api/v1/feature-service/metadata";
+  private static final String ENDPOINT = "api/v1/feature-service/metadata";
   private static final String DEFAULT_WORKSPACE = "prod";
 
   GetFeatureServiceMetadataRequest getFeatureServiceMetadataRequest;

--- a/src/test/java/ai/tecton/client/request/GetFeaturesBatchRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesBatchRequestTest.java
@@ -20,8 +20,8 @@ public class GetFeaturesBatchRequestTest {
 
   private static final String TEST_WORKSPACENAME = "testWorkspaceName";
   private static final String TEST_FEATURESERVICE_NAME = "testFSName";
-  private static final String BATCH_ENDPOINT = "/api/v1/feature-service/get-features-batch";
-  private static final String ENDPOINT = "/api/v1/feature-service/get-features";
+  private static final String BATCH_ENDPOINT = "api/v1/feature-service/get-features-batch";
+  private static final String ENDPOINT = "api/v1/feature-service/get-features";
 
   GetFeaturesBatchRequest getFeaturesBatchRequest;
   List<GetFeaturesRequestData> defaultFeatureRequestDataList;

--- a/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
@@ -16,7 +16,7 @@ public class GetFeaturesRequestTest {
 
   private static final String TEST_WORKSPACENAME = "testWorkspaceName";
   private static final String TEST_FEATURESERVICE_NAME = "testFSName";
-  private static final String ENDPOINT = "/api/v1/feature-service/get-features";
+  private static final String ENDPOINT = "api/v1/feature-service/get-features";
   private static final Set<MetadataOption> defaultMetadataOptions =
       EnumSet.of(MetadataOption.NAME, MetadataOption.DATA_TYPE);
 


### PR DESCRIPTION
A recent change to the feature server treats a url with double backslash as a malformed URL. Fix the URL in the client to skip the additional / in the path 