### PR TITLE
Handle all possible ValueTypes returned

### DIFF
--- a/src/main/java/ai/tecton/client/model/FeatureValue.java
+++ b/src/main/java/ai/tecton/client/model/FeatureValue.java
@@ -120,6 +120,7 @@ public class FeatureValue {
     private Long int64Value;
     private Boolean booleanValue;
     private Double float64Value;
+    private Double float32Value;
     private ListDataType listValue;
 
     // Primitive types
@@ -133,10 +134,11 @@ public class FeatureValue {
           this.stringValue = (String) featureObject;
           break;
         case INT64:
-          String stringValue = (String) featureObject;
-          if (stringValue != null) {
-            this.int64Value = Long.parseLong(stringValue);
-          }
+          // This should handle String, Integer, or Long types or null
+          this.int64Value = Optional.ofNullable(featureObject).map(Object::toString).map(Long::parseLong).orElse(null);
+          break;
+        case FLOAT32:
+          this.float32Value = (Double) featureObject;
           break;
         case FLOAT64:
           this.float64Value = (Double) featureObject;
@@ -185,6 +187,17 @@ public class FeatureValue {
   public Boolean booleanValue() throws TectonClientException {
     validateValueType(ValueType.BOOLEAN);
     return this.value.booleanValue;
+  }
+
+  /**
+   * A Feature Value of type Float32 (Double)
+   *
+   * @return feature value cast to java.lang.Double
+   * @throws TectonClientException if the method is called on a value whose ValueType is not FLOAT64
+   */
+  public Double float32Value() throws TectonClientException {
+    validateValueType(ValueType.FLOAT32);
+    return this.value.float32Value;
   }
 
   /**

--- a/src/test/java/ai/tecton/client/model/FeatureValueTest.java
+++ b/src/test/java/ai/tecton/client/model/FeatureValueTest.java
@@ -55,16 +55,49 @@ public class FeatureValueTest {
   }
 
   @Test
+  public void testFloat32Value() {
+    FeatureValue featureValue =
+            new FeatureValue(
+                    555.55,
+                    testName,
+                    ValueType.FLOAT32,
+                    Optional.empty(),
+                    null,
+                    Optional.ofNullable(FeatureStatus.PRESENT));
+
+    Assert.assertEquals("test_fs_name_space", featureValue.getFeatureNamespace());
+    Assert.assertEquals("test_fs_name", featureValue.getFeatureName());
+    Assert.assertEquals(ValueType.FLOAT32, featureValue.getValueType());
+    Assert.assertEquals(new Double(555.55), featureValue.float32Value());
+  }
+
+  @Test
   public void testInt64Value() {
 
     FeatureValue featureValue =
         new FeatureValue(
-            "0",
+            0,
             testName,
             ValueType.INT64,
             Optional.empty(),
             null,
             Optional.ofNullable(FeatureStatus.PRESENT));
+
+    Assert.assertEquals(ValueType.INT64, featureValue.getValueType());
+    Assert.assertEquals(new Long(0), featureValue.int64value());
+  }
+
+  @Test
+  public void testInt64ValueAsString() {
+
+    FeatureValue featureValue =
+            new FeatureValue(
+                    "0",
+                    testName,
+                    ValueType.INT64,
+                    Optional.empty(),
+                    null,
+                    Optional.ofNullable(FeatureStatus.PRESENT));
 
     Assert.assertEquals(ValueType.INT64, featureValue.getValueType());
     Assert.assertEquals(new Long(0), featureValue.int64value());


### PR DESCRIPTION
Previously FLOAT32 type wasn't handled at all. Int64 would throw a class cast exception if it actually came back from the REST API as integer instead of a String.