### PR TITLE
Allow join key values to be null

### DIFF
--- a/src/main/java/ai/tecton/client/model/FeatureValue.java
+++ b/src/main/java/ai/tecton/client/model/FeatureValue.java
@@ -123,6 +123,9 @@ public class FeatureValue {
     private ListDataType listValue;
 
     // Primitive types
+    // Float32 is currently not a supported type for feature values in Tecton. Refer here for all
+    // supported types :
+    // https://docs.tecton.ai/docs/faqs/creating_and_managing_features/#what-data-types-are-supported-for-feature-values
     public Value(Object featureObject, ValueType valueType) {
       this.valueType = valueType;
       switch (valueType) {
@@ -133,12 +136,14 @@ public class FeatureValue {
           this.stringValue = (String) featureObject;
           break;
         case INT64:
+          // Tecton represents all Int64 feature values as JSON strings in the response.
           String stringValue = (String) featureObject;
           if (stringValue != null) {
             this.int64Value = Long.parseLong(stringValue);
           }
           break;
         case FLOAT64:
+          // Tecton also represents all double feature values as JSON numbers in the response.
           this.float64Value = (Double) featureObject;
           break;
         default:

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
@@ -17,6 +17,7 @@ public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
   static final String ENDPOINT = "/api/v1/feature-service/get-features";
   private final JsonAdapter<GetFeaturesRequestJson> jsonAdapter;
   private final GetFeaturesRequestData getFeaturesRequestData;
+  private final Moshi moshi = new Moshi.Builder().build();
 
   /**
    * Constructor that creates a new GetFeaturesRequest with specified parameters. {@code
@@ -36,7 +37,6 @@ public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
     super(workspaceName, featureServiceName, ENDPOINT, RequestConstants.DEFAULT_METADATA_OPTIONS);
     validateRequestParameters(getFeaturesRequestData);
     this.getFeaturesRequestData = getFeaturesRequestData;
-    Moshi moshi = new Moshi.Builder().build();
     jsonAdapter = moshi.adapter(GetFeaturesRequestJson.class);
   }
 
@@ -63,7 +63,6 @@ public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
     super(workspaceName, featureServiceName, ENDPOINT, metadataOptions);
     validateRequestParameters(getFeaturesRequestData);
     this.getFeaturesRequestData = getFeaturesRequestData;
-    Moshi moshi = new Moshi.Builder().build();
     jsonAdapter = moshi.adapter(GetFeaturesRequestJson.class);
   }
 

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
@@ -37,10 +37,7 @@ public class GetFeaturesRequestData {
   public GetFeaturesRequestData addJoinKeyMap(Map<String, String> joinKeyMap)
       throws TectonClientException {
     Validate.notEmpty(joinKeyMap);
-    joinKeyMap.forEach(
-        (key, value) -> {
-          validateKeyValue(key, value, true);
-        });
+    joinKeyMap.forEach(this::validateKeyValue);
     this.joinKeyMap = joinKeyMap;
     return this;
   }
@@ -62,10 +59,7 @@ public class GetFeaturesRequestData {
   public GetFeaturesRequestData addRequestContextMap(Map<String, Object> requestContextMap)
       throws TectonClientException {
     Validate.notEmpty(requestContextMap);
-    requestContextMap.forEach(
-        (key, value) -> {
-          validateKeyValue(key, value, false);
-        });
+    requestContextMap.forEach(this::validateKeyValueDisallowingNullValue);
     this.requestContextMap = requestContextMap;
     return this;
   }
@@ -79,7 +73,7 @@ public class GetFeaturesRequestData {
    * @throws TectonClientException when the join key or value is null or empty
    */
   public GetFeaturesRequestData addJoinKey(String key, String value) throws TectonClientException {
-    validateKeyValue(key, value, true);
+    validateKeyValue(key, value);
     joinKeyMap.put(key, value);
     return this;
   }
@@ -94,7 +88,7 @@ public class GetFeaturesRequestData {
    */
   public GetFeaturesRequestData addJoinKey(String key, Long value) throws TectonClientException {
     String joinKeyValue = (value == null) ? null : value.toString();
-    validateKeyValue(key, joinKeyValue, true);
+    validateKeyValue(key, joinKeyValue);
     joinKeyMap.put(key, joinKeyValue);
     return this;
   }
@@ -109,7 +103,7 @@ public class GetFeaturesRequestData {
    */
   public GetFeaturesRequestData addRequestContext(String key, String value)
       throws TectonClientException {
-    validateKeyValue(key, value, false);
+    validateKeyValueDisallowingNullValue(key, value);
     requestContextMap.put(key, value);
     return this;
   }
@@ -126,7 +120,7 @@ public class GetFeaturesRequestData {
    */
   public GetFeaturesRequestData addRequestContext(String key, Long value)
       throws TectonClientException {
-    validateKeyValue(key, value, false);
+    validateKeyValueDisallowingNullValue(key, value);
     requestContextMap.put(key, value.toString());
     return this;
   }
@@ -141,7 +135,7 @@ public class GetFeaturesRequestData {
    */
   public GetFeaturesRequestData addRequestContext(String key, Double value)
       throws TectonClientException {
-    validateKeyValue(key, value, false);
+    validateKeyValueDisallowingNullValue(key, value);
     requestContextMap.put(key, value);
     return this;
   }
@@ -162,13 +156,15 @@ public class GetFeaturesRequestData {
     return this.requestContextMap.isEmpty();
   }
 
-  private void validateKeyValue(String key, Object value, boolean allowNullValue) {
+  private void validateKeyValue(String key, Object value) {
     Validate.notEmpty(key, TectonErrorMessage.INVALID_KEY_VALUE);
-    if (!allowNullValue) {
-      Validate.notNull(value, TectonErrorMessage.INVALID_KEY_VALUE);
-    }
     if (value instanceof String) {
       Validate.notEmpty((String) value, TectonErrorMessage.INVALID_KEY_VALUE);
     }
+  }
+
+  private void validateKeyValueDisallowingNullValue(String key, Object value) {
+    validateKeyValue(key, value);
+    Validate.notNull(value, TectonErrorMessage.INVALID_KEY_VALUE);
   }
 }

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
@@ -37,7 +37,10 @@ public class GetFeaturesRequestData {
   public GetFeaturesRequestData addJoinKeyMap(Map<String, String> joinKeyMap)
       throws TectonClientException {
     Validate.notEmpty(joinKeyMap);
-    joinKeyMap.forEach(this::validateKeyValue);
+    joinKeyMap.forEach(
+        (key, value) -> {
+          validateKeyValue(key, value, true);
+        });
     this.joinKeyMap = joinKeyMap;
     return this;
   }
@@ -59,7 +62,10 @@ public class GetFeaturesRequestData {
   public GetFeaturesRequestData addRequestContextMap(Map<String, Object> requestContextMap)
       throws TectonClientException {
     Validate.notEmpty(requestContextMap);
-    requestContextMap.forEach(this::validateKeyValue);
+    requestContextMap.forEach(
+        (key, value) -> {
+          validateKeyValue(key, value, false);
+        });
     this.requestContextMap = requestContextMap;
     return this;
   }
@@ -73,7 +79,7 @@ public class GetFeaturesRequestData {
    * @throws TectonClientException when the join key or value is null or empty
    */
   public GetFeaturesRequestData addJoinKey(String key, String value) throws TectonClientException {
-    validateKeyValue(key, value);
+    validateKeyValue(key, value, true);
     joinKeyMap.put(key, value);
     return this;
   }
@@ -87,8 +93,9 @@ public class GetFeaturesRequestData {
    * @throws TectonClientException when the join key or value is null or empty
    */
   public GetFeaturesRequestData addJoinKey(String key, Long value) throws TectonClientException {
-    validateKeyValue(key, value.toString());
-    joinKeyMap.put(key, value.toString());
+    String joinKeyValue = (value == null) ? null : value.toString();
+    validateKeyValue(key, joinKeyValue, true);
+    joinKeyMap.put(key, joinKeyValue);
     return this;
   }
 
@@ -102,7 +109,7 @@ public class GetFeaturesRequestData {
    */
   public GetFeaturesRequestData addRequestContext(String key, String value)
       throws TectonClientException {
-    validateKeyValue(key, value);
+    validateKeyValue(key, value, false);
     requestContextMap.put(key, value);
     return this;
   }
@@ -119,7 +126,7 @@ public class GetFeaturesRequestData {
    */
   public GetFeaturesRequestData addRequestContext(String key, Long value)
       throws TectonClientException {
-    validateKeyValue(key, value);
+    validateKeyValue(key, value, false);
     requestContextMap.put(key, value.toString());
     return this;
   }
@@ -134,7 +141,7 @@ public class GetFeaturesRequestData {
    */
   public GetFeaturesRequestData addRequestContext(String key, Double value)
       throws TectonClientException {
-    validateKeyValue(key, value);
+    validateKeyValue(key, value, false);
     requestContextMap.put(key, value);
     return this;
   }
@@ -155,10 +162,11 @@ public class GetFeaturesRequestData {
     return this.requestContextMap.isEmpty();
   }
 
-  private void validateKeyValue(String key, Object value) {
+  private void validateKeyValue(String key, Object value, boolean allowNullValue) {
     Validate.notEmpty(key, TectonErrorMessage.INVALID_KEY_VALUE);
-    Validate.notNull(value, TectonErrorMessage.INVALID_KEY_VALUE);
-
+    if (!allowNullValue) {
+      Validate.notNull(value, TectonErrorMessage.INVALID_KEY_VALUE);
+    }
     if (value instanceof String) {
       Validate.notEmpty((String) value, TectonErrorMessage.INVALID_KEY_VALUE);
     }

--- a/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
@@ -29,12 +29,11 @@ public class GetFeatureRequestDataTest {
   }
 
   @Test
-  public void testNullJoinValue() {
+  public void testShouldAllowNullJoinValue() {
     try {
       getFeaturesRequestData.addJoinKey("testKey", (String) null);
-      fail();
     } catch (NullPointerException e) {
-      Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
+      fail();
     }
   }
 


### PR DESCRIPTION

The FeatureService REST API allows join key values to be null. For consistency we should also let the values be null in the Java Client. 

This PR also adds descriptive comments to some special cases in the code.