### PR TITLE
Add Equals and HashCode to Request and Response Classes

### DIFF
--- a/src/main/java/ai/tecton/client/TectonClient.java
+++ b/src/main/java/ai/tecton/client/TectonClient.java
@@ -188,4 +188,85 @@ public class TectonClient {
     }
     return httpResponse;
   }
+
+  /**
+   * A Builder class for creating an instance of {@link TectonClient} object with specific
+   * configurations
+   */
+  public static class Builder {
+    private String url;
+    private String apiKey;
+    private TectonClientOptions tectonClientOptions;
+    private OkHttpClient httpClient;
+
+    /**
+     * Setter for url
+     *
+     * @param url The Tecton Base Url
+     * @return this Builder
+     */
+    public Builder url(String url) {
+      this.url = url;
+      return this;
+    }
+
+    /**
+     * Setter for apiKey
+     *
+     * @param apiKey API Key for authenticating with the FeatureService API. See <a
+     *     href="https://docs.tecton.ai/docs/reading-feature-data/reading-feature-data-for-inference/reading-online-features-for-inference-using-the-http-api#creating-an-api-key-to-authenticate-to-the-http-api">Authenticating
+     *     with an API key</a> for more information
+     * @return this Builder
+     */
+    public Builder apiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    /**
+     * Setter for tectonClientOptions
+     *
+     * @param tectonClientOptions A {@link TectonClientOptions} object with custom configurations
+     * @return this Builder
+     */
+    public Builder tectonClientOptions(TectonClientOptions tectonClientOptions) {
+      this.tectonClientOptions = tectonClientOptions;
+      return this;
+    }
+
+    /**
+     * Setter for httpClient
+     *
+     * @param httpClient An OkHttpClient for making requests and receiving responses from the
+     *     Feature Service API. Please refer to <a
+     *     href="https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/">OkHttp
+     *     Documentation</a> for recommendations on creating and maintaining an OkHttp Client in
+     *     your application. Tecton recommends configuring the <a
+     *     href="https://square.github.io/okhttp/4.x/okhttp/okhttp3/-connection-pool">ConnectionPool</a>
+     *     in the OkHttpClient for efficiently managing HTTP connections. If you intend to use the
+     *     {@link GetFeaturesBatchRequest} to send parallel requests to Tecton, please also
+     *     configure the <a
+     *     href="https://square.github.io/okhttp/4.x/okhttp/okhttp3/-dispatcher/max-requests-per-host">maxRequestsPerHost</a>
+     *     in the client's Dispatcher.
+     * @return this Builder
+     */
+    public Builder httpClient(OkHttpClient httpClient) {
+      this.httpClient = httpClient;
+      return this;
+    }
+
+    /**
+     * Build a {@link TectonClient} object from the Builder
+     *
+     * @return {@link TectonClient}
+     */
+    public TectonClient build() {
+      if (this.httpClient != null) {
+        return new TectonClient(url, apiKey, httpClient);
+      } else if (this.tectonClientOptions != null) {
+        return new TectonClient(url, apiKey, tectonClientOptions);
+      }
+      return new TectonClient(url, apiKey);
+    }
+  }
 }

--- a/src/main/java/ai/tecton/client/TectonClientOptions.java
+++ b/src/main/java/ai/tecton/client/TectonClientOptions.java
@@ -178,6 +178,11 @@ public class TectonClientOptions {
       return this;
     }
 
+    /**
+     * Build a {@link TectonClientOptions} object from the Builder
+     *
+     * @return {@link TectonClientOptions}
+     */
     public TectonClientOptions build() {
       return new TectonClientOptions(
           this.readTimeout,

--- a/src/main/java/ai/tecton/client/model/FeatureServiceMetadata.java
+++ b/src/main/java/ai/tecton/client/model/FeatureServiceMetadata.java
@@ -3,6 +3,7 @@ package ai.tecton.client.model;
 import ai.tecton.client.request.GetFeaturesRequest;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -82,5 +83,22 @@ public class FeatureServiceMetadata {
   public Map<String, NameAndType> getFeatureValuesAsMap() {
     return this.featureValues.stream()
         .collect(Collectors.toMap(NameAndType::getName, Function.identity()));
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FeatureServiceMetadata that = (FeatureServiceMetadata) o;
+    return Objects.equals(inputJoinKeys, that.inputJoinKeys)
+        && Objects.equals(inputRequestContextKeys, that.inputRequestContextKeys)
+        && Objects.equals(featureValues, that.featureValues);
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(inputJoinKeys, inputRequestContextKeys, featureValues);
   }
 }

--- a/src/main/java/ai/tecton/client/model/FeatureValue.java
+++ b/src/main/java/ai/tecton/client/model/FeatureValue.java
@@ -12,7 +12,6 @@ import org.apache.commons.lang3.StringUtils;
  * GetFeaturesResponse
  */
 public class FeatureValue {
-
   private final SimpleDateFormat dateFormat =
       new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
 
@@ -121,6 +120,25 @@ public class FeatureValue {
     private Boolean booleanValue;
     private Double float64Value;
     private ListDataType listValue;
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Value value = (Value) o;
+      return valueType == value.valueType
+          && Objects.equals(stringValue, value.stringValue)
+          && Objects.equals(int64Value, value.int64Value)
+          && Objects.equals(booleanValue, value.booleanValue)
+          && Objects.equals(float64Value, value.float64Value)
+          && Objects.equals(listValue, value.listValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          valueType, stringValue, int64Value, booleanValue, float64Value, listValue);
+    }
 
     // Primitive types
     // Float32 is currently not a supported type for feature values in Tecton. Refer here for all
@@ -265,5 +283,24 @@ public class FeatureValue {
           String.format(
               TectonErrorMessage.MISMATCHED_TYPE, value.listValue.listElementType.getName()));
     }
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FeatureValue that = (FeatureValue) o;
+    return Objects.equals(featureNamespace, that.featureNamespace)
+        && Objects.equals(featureName, that.featureName)
+        && Objects.equals(effectiveTime, that.effectiveTime)
+        && Objects.equals(value, that.value)
+        && Objects.equals(featureStatus, that.featureStatus);
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(featureNamespace, featureName, effectiveTime, value, featureStatus);
   }
 }

--- a/src/main/java/ai/tecton/client/model/ListDataType.java
+++ b/src/main/java/ai/tecton/client/model/ListDataType.java
@@ -51,7 +51,7 @@ class ListDataType {
         && Objects.equals(float32List, that.float32List)
         && Objects.equals(float64List, that.float64List)
         && Objects.equals(int64List, that.int64List)
-        && listElementType == that.listElementType;
+        && Objects.equals(listElementType, that.listElementType);
   }
 
   /** Overrides <i>hashCode()</i> in class {@link Object} */

--- a/src/main/java/ai/tecton/client/model/ListDataType.java
+++ b/src/main/java/ai/tecton/client/model/ListDataType.java
@@ -4,9 +4,11 @@ import ai.tecton.client.exceptions.TectonClientException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @SuppressWarnings("unchecked")
 class ListDataType {
+
   List<String> stringList;
   List<Float> float32List;
   List<Double> float64List;
@@ -37,5 +39,24 @@ class ListDataType {
       default:
         throw new TectonClientException(TectonErrorMessage.UNSUPPORTED_LIST_DATA_TYPE);
     }
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ListDataType that = (ListDataType) o;
+    return Objects.equals(stringList, that.stringList)
+        && Objects.equals(float32List, that.float32List)
+        && Objects.equals(float64List, that.float64List)
+        && Objects.equals(int64List, that.int64List)
+        && listElementType == that.listElementType;
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(stringList, float32List, float64List, int64List, listElementType);
   }
 }

--- a/src/main/java/ai/tecton/client/model/NameAndType.java
+++ b/src/main/java/ai/tecton/client/model/NameAndType.java
@@ -1,9 +1,11 @@
 package ai.tecton.client.model;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /** Class that represents the return types for parameters of FeatureServiceMetadata */
 public class NameAndType {
+
   String name;
   ValueType dataType;
   ValueType listElementType;
@@ -57,5 +59,22 @@ public class NameAndType {
    */
   public Optional<ValueType> getListElementType() {
     return Optional.ofNullable(this.listElementType);
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    NameAndType that = (NameAndType) o;
+    return Objects.equals(name, that.name)
+        && dataType == that.dataType
+        && listElementType == that.listElementType;
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, dataType, listElementType);
   }
 }

--- a/src/main/java/ai/tecton/client/model/SloInformation.java
+++ b/src/main/java/ai/tecton/client/model/SloInformation.java
@@ -1,6 +1,7 @@
 package ai.tecton.client.model;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -9,6 +10,7 @@ import java.util.Set;
  * returned are wrapped in {@link }
  */
 public class SloInformation {
+
   private Boolean sloEligible;
 
   private Double serverTimeSeconds;
@@ -148,5 +150,31 @@ public class SloInformation {
           this.sloIneligibilityReasons,
           this.storeMaxLatency);
     }
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SloInformation that = (SloInformation) o;
+    return Objects.equals(sloEligible, that.sloEligible)
+        && Objects.equals(serverTimeSeconds, that.serverTimeSeconds)
+        && Objects.equals(sloServerTimeSeconds, that.sloServerTimeSeconds)
+        && Objects.equals(storeResponseSizeBytes, that.storeResponseSizeBytes)
+        && Objects.equals(sloIneligibilityReasons, that.sloIneligibilityReasons)
+        && Objects.equals(storeMaxLatency, that.storeMaxLatency);
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        sloEligible,
+        serverTimeSeconds,
+        sloServerTimeSeconds,
+        storeResponseSizeBytes,
+        sloIneligibilityReasons,
+        storeMaxLatency);
   }
 }

--- a/src/main/java/ai/tecton/client/request/AbstractGetFeaturesRequest.java
+++ b/src/main/java/ai/tecton/client/request/AbstractGetFeaturesRequest.java
@@ -13,6 +13,7 @@ import com.squareup.moshi.Types;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.reflect.Type;
+import java.util.Objects;
 import java.util.Set;
 import org.jetbrains.annotations.Nullable;
 
@@ -81,5 +82,19 @@ public abstract class AbstractGetFeaturesRequest extends AbstractTectonRequest {
             return moshi.nextAdapter(this, type, nextAnnotations).serializeNulls();
           }
         };
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    AbstractGetFeaturesRequest that = (AbstractGetFeaturesRequest) o;
+    return Objects.equals(metadataOptions, that.metadataOptions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), metadataOptions);
   }
 }

--- a/src/main/java/ai/tecton/client/request/AbstractTectonRequest.java
+++ b/src/main/java/ai/tecton/client/request/AbstractTectonRequest.java
@@ -3,6 +3,7 @@ package ai.tecton.client.request;
 import ai.tecton.client.exceptions.TectonClientException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.transport.TectonHttpClient;
+import java.util.Objects;
 import org.apache.commons.lang3.Validate;
 
 /** An abstract parent class for Tecton FeatureService API Request subclasses */
@@ -68,5 +69,21 @@ public abstract class AbstractTectonRequest {
     } catch (Exception e) {
       throw new TectonClientException(e.getMessage());
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    AbstractTectonRequest that = (AbstractTectonRequest) o;
+    return endpoint.equals(that.endpoint)
+        && method == that.method
+        && workspaceName.equals(that.workspaceName)
+        && featureServiceName.equals(that.featureServiceName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(endpoint, method, workspaceName, featureServiceName);
   }
 }

--- a/src/main/java/ai/tecton/client/request/GetFeatureServiceMetadataRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeatureServiceMetadataRequest.java
@@ -57,6 +57,11 @@ public class GetFeatureServiceMetadataRequest extends AbstractTectonRequest {
     String workspace_name;
   }
 
+  /**
+   * Get the JSON representation of the request that will be sent to the /metadata endpoint.
+   *
+   * @return JSON String representation of {@link GetFeatureServiceMetadataRequest}
+   */
   @Override
   public String requestToJson() {
     GetFeatureServiceMetadataFields serviceMetadataFields = new GetFeatureServiceMetadataFields();
@@ -68,6 +73,48 @@ public class GetFeatureServiceMetadataRequest extends AbstractTectonRequest {
     } catch (Exception e) {
       throw new TectonClientException(
           String.format(TectonErrorMessage.INVALID_GET_SERVICE_METADATA_REQUEST, e.getMessage()));
+    }
+  }
+
+  /**
+   * A Builder class for building instances of {@link GetFeatureServiceMetadataRequest} objects from
+   * values configured by setters
+   */
+  public static final class Builder {
+    private String workspaceName;
+    private String featureServiceName;
+
+    /**
+     * Setter for workspaceName
+     *
+     * @param workspaceName Name of the workspace to fetch metadata for the FeatureService from
+     * @return this Builder
+     */
+    public Builder workspaceName(String workspaceName) {
+      this.workspaceName = workspaceName;
+      return this;
+    }
+
+    /**
+     * Setter for featureServiceName
+     *
+     * @param featureServiceName Name of the Feature Service for which the metadata is being
+     *     requested
+     * @return this Builder
+     */
+    public Builder featureServiceName(String featureServiceName) {
+      this.featureServiceName = featureServiceName;
+      return this;
+    }
+
+    /**
+     * Returns an instance of {@link GetFeatureServiceMetadataRequest}
+     *
+     * @return {@link GetFeatureServiceMetadataRequest} object
+     * @throws TectonClientException when workspaceName and/or featureServiceName is null or empty
+     */
+    public GetFeatureServiceMetadataRequest build() {
+      return new GetFeatureServiceMetadataRequest(featureServiceName, workspaceName);
     }
   }
 }

--- a/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
@@ -7,7 +7,11 @@ import ai.tecton.client.transport.TectonHttpClient;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
 

--- a/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
@@ -7,10 +7,7 @@ import ai.tecton.client.transport.TectonHttpClient;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
 
@@ -475,5 +472,38 @@ public class GetFeaturesBatchRequest {
             String.format(TectonErrorMessage.INVALID_GET_FEATURE_BATCH_REQUEST, e.getMessage()));
       }
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      if (!super.equals(o)) return false;
+      GetFeaturesMicroBatchRequest that = (GetFeaturesMicroBatchRequest) o;
+      return requestDataList.equals(that.requestDataList);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(super.hashCode(), requestDataList);
+    }
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GetFeaturesBatchRequest that = (GetFeaturesBatchRequest) o;
+    return microBatchSize == that.microBatchSize
+        && Objects.equals(requestList, that.requestList)
+        && Objects.equals(timeout, that.timeout)
+        && Objects.equals(endpoint, that.endpoint)
+        && method == that.method;
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(requestList, microBatchSize, timeout, endpoint, method);
   }
 }

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
@@ -86,6 +86,11 @@ public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
     Map<String, Boolean> metadata_options;
   }
 
+  /**
+   * Get the JSON representation of the request that will be sent to the /get-features endpoint.
+   *
+   * @return JSON String representation of {@link GetFeaturesRequest}
+   */
   @Override
   public String requestToJson() {
     GetFeaturesFields getFeaturesFields = new GetFeaturesFields();
@@ -108,6 +113,103 @@ public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
     } catch (Exception e) {
       throw new TectonClientException(
           String.format(TectonErrorMessage.INVALID_GET_FEATURE_REQUEST, e.getMessage()));
+    }
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    GetFeaturesRequest that = (GetFeaturesRequest) o;
+    return getFeaturesRequestData.equals(that.getFeaturesRequestData);
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), getFeaturesRequestData);
+  }
+
+  /**
+   * A Builder class for building instances of {@link GetFeaturesRequest} objects from values
+   * configured by setters
+   */
+  public static final class Builder {
+    Set<MetadataOption> metadataOptions;
+    private String workspaceName;
+    private String featureServiceName;
+    private GetFeaturesRequestData getFeaturesRequestData;
+
+    /** Constructor for instantiating an empty Builder */
+    public Builder() {
+      this.metadataOptions = new HashSet<>();
+    }
+
+    /**
+     * Setter for metadataOptions
+     *
+     * @param metadataOptions A {@link Set} of {@link MetadataOption} for retrieving additional
+     *     metadata about the feature values. Use {@link RequestConstants#ALL_METADATA_OPTIONS} to
+     *     request all metadata and {@link RequestConstants#NONE_METADATA_OPTIONS} to request no
+     *     metadata respectively. By default, {@link RequestConstants#DEFAULT_METADATA_OPTIONS} will
+     *     be added to each request
+     * @return this Builder
+     */
+    public Builder metadataOptions(Set<MetadataOption> metadataOptions) {
+      this.metadataOptions = metadataOptions;
+      return this;
+    }
+
+    /**
+     * Setter for workspaceName
+     *
+     * @param workspaceName Name of the workspace in which the Feature Service is defined
+     * @return this Builder
+     */
+    public Builder workspaceName(String workspaceName) {
+      this.workspaceName = workspaceName;
+      return this;
+    }
+
+    /**
+     * Setter for featureServiceName
+     *
+     * @param featureServiceName Name of the Feature Service for which the feature vector is being
+     *     requested
+     * @return this Builder
+     */
+    public Builder featureServiceName(String featureServiceName) {
+      this.featureServiceName = featureServiceName;
+      return this;
+    }
+
+    /**
+     * Setter for {@link GetFeaturesRequestData}
+     *
+     * @param getFeaturesRequestData {@link GetFeaturesRequestData} object with joinKeyMap and/or
+     *     requestContextMap
+     * @return this Builder
+     */
+    public Builder getFeaturesRequestData(GetFeaturesRequestData getFeaturesRequestData) {
+      this.getFeaturesRequestData = getFeaturesRequestData;
+      return this;
+    }
+
+    /**
+     * Returns an instance of {@link GetFeaturesRequest} created from the fields set on this builder
+     *
+     * @return {@link GetFeaturesRequest} object
+     * @throws TectonClientException when workspaceName and/or featureServiceName is null or empty
+     */
+    public GetFeaturesRequest build() {
+      if (this.metadataOptions.isEmpty()) {
+        return new GetFeaturesRequest(workspaceName, featureServiceName, getFeaturesRequestData);
+      } else {
+        return new GetFeaturesRequest(
+            workspaceName, featureServiceName, getFeaturesRequestData, metadataOptions);
+      }
     }
   }
 }

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
@@ -5,7 +5,10 @@ import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.model.MetadataOption;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
@@ -4,6 +4,7 @@ import ai.tecton.client.exceptions.TectonClientException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.commons.lang3.Validate;
 
 /** Class that represents the map parameters passed to a {@link GetFeaturesRequest} */
@@ -166,5 +167,73 @@ public class GetFeaturesRequestData {
   private void validateKeyValueDisallowingNullValue(String key, Object value) {
     validateKeyValue(key, value);
     Validate.notNull(value, TectonErrorMessage.INVALID_KEY_VALUE);
+  }
+
+  /** A Builder class for creating an instance of {@link GetFeaturesRequestData} object */
+  public static class Builder {
+    private GetFeaturesRequestData getFeaturesRequestData;
+
+    /** Instantiates a new Builder */
+    public Builder() {
+      getFeaturesRequestData = new GetFeaturesRequestData();
+    }
+
+    /**
+     * Setter for joinKeyMap
+     *
+     * @param joinKeyMap Join keys used for table-based FeatureViews.
+     *     <p>The key of this map is the join key name and the value is the join key value for this
+     *     request
+     *     <p>For string keys, the value should be a string
+     *     <p>For int64 (Long) keys, the value should be a string of the decimal representation of
+     *     the integer
+     * @return this Builder
+     */
+    public Builder joinKeyMap(Map<String, String> joinKeyMap) {
+      getFeaturesRequestData = getFeaturesRequestData.addJoinKeyMap(joinKeyMap);
+      return this;
+    }
+
+    /**
+     * Setter for requestContextMap
+     *
+     * @param requestContextMap Request context used for OnDemand FeatureViews.
+     *     <p>The key of this map is the join key name and the value is the join key value for this
+     *     request
+     *     <p>For string values, the value should be a java.lang.String
+     *     <p>For int64 values, the value should be a java.lang.String of the decimal representation
+     *     of the integer
+     *     <p>For double values, the value should be a java.lang.Double
+     * @return this Builder
+     */
+    public Builder requestContextMap(Map<String, Object> requestContextMap) {
+      getFeaturesRequestData = getFeaturesRequestData.addRequestContextMap(requestContextMap);
+      return this;
+    }
+
+    /**
+     * Build a {@link GetFeaturesRequestData} object from the Builder
+     *
+     * @return {@link GetFeaturesRequestData}
+     */
+    public GetFeaturesRequestData build() {
+      return this.getFeaturesRequestData;
+    }
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GetFeaturesRequestData that = (GetFeaturesRequestData) o;
+    return Objects.equals(joinKeyMap, that.joinKeyMap)
+        && Objects.equals(requestContextMap, that.requestContextMap);
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(joinKeyMap, requestContextMap);
   }
 }

--- a/src/main/java/ai/tecton/client/response/GetFeaturesBatchResponse.java
+++ b/src/main/java/ai/tecton/client/response/GetFeaturesBatchResponse.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
  * (i.e. microBatchSize&gt;1)
  */
 public class GetFeaturesBatchResponse {
+
   private final List<GetFeaturesResponse> batchResponseList;
 
   private SloInformation batchSloInfo;
@@ -98,6 +99,22 @@ public class GetFeaturesBatchResponse {
    */
   public Optional<SloInformation> getBatchSloInformation() {
     return Optional.ofNullable(this.batchSloInfo);
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GetFeaturesBatchResponse that = (GetFeaturesBatchResponse) o;
+    return Objects.equals(batchResponseList, that.batchResponseList)
+        && Objects.equals(batchSloInfo, that.batchSloInfo);
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(batchResponseList, batchSloInfo);
   }
 
   // Parse a single HttpResponse and extract GetFeaturesResponse, SloInformation

--- a/src/main/java/ai/tecton/client/response/GetFeaturesResponse.java
+++ b/src/main/java/ai/tecton/client/response/GetFeaturesResponse.java
@@ -146,4 +146,20 @@ public class GetFeaturesResponse extends AbstractTectonResponse {
       }
     }
   }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GetFeaturesResponse that = (GetFeaturesResponse) o;
+    return Objects.equals(featureValues, that.featureValues)
+        && Objects.equals(sloInformation, that.sloInformation);
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(featureValues, sloInformation);
+  }
 }

--- a/src/test/java/ai/tecton/client/model/FeatureValueTest.java
+++ b/src/test/java/ai/tecton/client/model/FeatureValueTest.java
@@ -154,4 +154,38 @@ public class FeatureValueTest {
       Assert.assertEquals(message, e.getMessage());
     }
   }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    FeatureValue featureValue =
+        new FeatureValue(
+            "123",
+            testName,
+            ValueType.STRING,
+            Optional.empty(),
+            null,
+            Optional.ofNullable(FeatureStatus.PRESENT));
+    FeatureValue featureValueEquals =
+        new FeatureValue(
+            "123",
+            testName,
+            ValueType.STRING,
+            Optional.empty(),
+            null,
+            Optional.ofNullable(FeatureStatus.PRESENT));
+    FeatureValue featureValueNotEquals =
+        new FeatureValue(
+            "123",
+            testName,
+            ValueType.INT64,
+            Optional.empty(),
+            null,
+            Optional.ofNullable(FeatureStatus.PRESENT));
+
+    Assert.assertEquals(featureValue, featureValueEquals);
+    Assert.assertEquals(featureValue.hashCode(), featureValueEquals.hashCode());
+
+    Assert.assertNotEquals(featureValue, featureValueNotEquals);
+    Assert.assertNotEquals(featureValue.hashCode(), featureValueNotEquals.hashCode());
+  }
 }

--- a/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
@@ -164,4 +164,41 @@ public class GetFeatureRequestDataTest {
                   getFeaturesRequestData.getRequestContextMap().get(key));
             });
   }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    Map<String, String> joinKeyMap =
+        new HashMap<String, String>() {
+          {
+            put("user_id", "123");
+          }
+        };
+    Map<String, Object> requestContextMap =
+        new HashMap<String, Object>() {
+          {
+            put("amount", 500.00);
+          }
+        };
+
+    GetFeaturesRequestData requestData =
+        new GetFeaturesRequestData.Builder()
+            .joinKeyMap(joinKeyMap)
+            .requestContextMap(requestContextMap)
+            .build();
+    GetFeaturesRequestData requestDataEquals =
+        new GetFeaturesRequestData()
+            .addJoinKeyMap(joinKeyMap)
+            .addRequestContextMap(requestContextMap);
+    GetFeaturesRequestData requestDataNotEquals =
+        new GetFeaturesRequestData()
+            .addJoinKeyMap(new HashMap<>(joinKeyMap))
+            .addRequestContextMap(requestContextMap)
+            .addJoinKey("ad_id", "1234");
+
+    Assert.assertEquals(requestData, requestDataEquals);
+    Assert.assertEquals(requestData.hashCode(), requestDataEquals.hashCode());
+
+    Assert.assertNotEquals(requestData, requestDataNotEquals);
+    Assert.assertNotEquals(requestData.hashCode(), requestDataNotEquals.hashCode());
+  }
 }

--- a/src/test/java/ai/tecton/client/request/GetFeatureServiceMetadataRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeatureServiceMetadataRequestTest.java
@@ -62,4 +62,33 @@ public class GetFeatureServiceMetadataRequestTest {
       Assert.assertEquals(TectonErrorMessage.INVALID_FEATURESERVICENAME, e.getMessage());
     }
   }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    GetFeatureServiceMetadataRequest getFeatureServiceMetadataRequest =
+        new GetFeatureServiceMetadataRequest(TEST_FEATURESERVICE_NAME, TEST_WORKSPACENAME);
+
+    GetFeatureServiceMetadataRequest getFeatureServiceMetadataRequestEquals =
+        new GetFeatureServiceMetadataRequest.Builder()
+            .featureServiceName(TEST_FEATURESERVICE_NAME)
+            .workspaceName(TEST_WORKSPACENAME)
+            .build();
+
+    GetFeatureServiceMetadataRequest getFeatureServiceMetadataRequestNotEquals =
+        new GetFeatureServiceMetadataRequest.Builder()
+            .featureServiceName(TEST_FEATURESERVICE_NAME)
+            .workspaceName("dev_workspace")
+            .build();
+
+    Assert.assertEquals(getFeatureServiceMetadataRequest, getFeatureServiceMetadataRequestEquals);
+    Assert.assertEquals(
+        getFeatureServiceMetadataRequest.hashCode(),
+        getFeatureServiceMetadataRequestEquals.hashCode());
+
+    Assert.assertNotEquals(
+        getFeatureServiceMetadataRequest, getFeatureServiceMetadataRequestNotEquals);
+    Assert.assertNotEquals(
+        getFeatureServiceMetadataRequest.hashCode(),
+        getFeatureServiceMetadataRequestNotEquals.hashCode());
+  }
 }

--- a/src/test/java/ai/tecton/client/request/GetFeaturesBatchRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesBatchRequestTest.java
@@ -330,6 +330,43 @@ public class GetFeaturesBatchRequestTest {
     Assert.assertEquals(expected, actual);
   }
 
+  @Test
+  public void testEqualsAndHashCode() {
+    List<GetFeaturesRequestData> requestDataList = TestUtils.generateRequestDataForSize(3);
+
+    GetFeaturesBatchRequest getFeaturesBatchRequest =
+        new GetFeaturesBatchRequest.Builder()
+            .workspaceName(TEST_WORKSPACENAME)
+            .featureServiceName(TEST_FEATURESERVICE_NAME)
+            .requestDataList(requestDataList)
+            .microBatchSize(1)
+            .build();
+
+    GetFeaturesBatchRequest getFeaturesBatchRequestEquals =
+        new GetFeaturesBatchRequest.Builder()
+            .workspaceName(TEST_WORKSPACENAME)
+            .featureServiceName(TEST_FEATURESERVICE_NAME)
+            .requestDataList(requestDataList)
+            .microBatchSize(1)
+            .build();
+
+    GetFeaturesBatchRequest getFeaturesBatchRequestNotEquals =
+        new GetFeaturesBatchRequest.Builder()
+            .workspaceName(TEST_WORKSPACENAME)
+            .featureServiceName(TEST_FEATURESERVICE_NAME)
+            .requestDataList(requestDataList)
+            .microBatchSize(3)
+            .build();
+
+    Assert.assertEquals(getFeaturesBatchRequest, getFeaturesBatchRequestEquals);
+    Assert.assertEquals(
+        getFeaturesBatchRequest.hashCode(), getFeaturesBatchRequestEquals.hashCode());
+
+    Assert.assertNotEquals(getFeaturesBatchRequest, getFeaturesBatchRequestNotEquals);
+    Assert.assertNotEquals(
+        getFeaturesBatchRequest.hashCode(), getFeaturesBatchRequestNotEquals.hashCode());
+  }
+
   private void checkGetFeaturesCommonFields(
       AbstractGetFeaturesRequest getFeaturesRequest,
       String endpoint,

--- a/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
@@ -263,4 +263,31 @@ public class GetFeaturesRequestTest {
     String actual_json = getFeaturesRequest.requestToJson();
     Assert.assertEquals(expected_json, actual_json);
   }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    GetFeaturesRequest getFeaturesRequest =
+        new GetFeaturesRequest(
+            TEST_WORKSPACENAME, TEST_FEATURESERVICE_NAME, defaultFeatureRequestData);
+
+    GetFeaturesRequest getFeaturesRequestEquals =
+        new GetFeaturesRequest.Builder()
+            .workspaceName(TEST_WORKSPACENAME)
+            .featureServiceName(TEST_FEATURESERVICE_NAME)
+            .getFeaturesRequestData(defaultFeatureRequestData)
+            .build();
+
+    GetFeaturesRequest getFeaturesRequestNotEquals =
+        new GetFeaturesRequest.Builder()
+            .workspaceName("dev_workspace")
+            .featureServiceName(TEST_FEATURESERVICE_NAME)
+            .getFeaturesRequestData(defaultFeatureRequestData)
+            .build();
+
+    Assert.assertEquals(getFeaturesRequest, getFeaturesRequestEquals);
+    Assert.assertEquals(getFeaturesRequest.hashCode(), getFeaturesRequestEquals.hashCode());
+
+    Assert.assertNotEquals(getFeaturesRequest, getFeaturesRequestNotEquals);
+    Assert.assertNotEquals(getFeaturesRequest.hashCode(), getFeaturesRequestNotEquals.hashCode());
+  }
 }

--- a/src/test/java/ai/tecton/client/response/GetFeaturesResponseTest.java
+++ b/src/test/java/ai/tecton/client/response/GetFeaturesResponseTest.java
@@ -113,6 +113,21 @@ public class GetFeaturesResponseTest {
     Assert.assertEquals(expectedLongArray, actualLongArray);
   }
 
+  @Test
+  public void testEqualsAndHashCode() {
+    GetFeaturesResponse getFeaturesResponse =
+        new GetFeaturesResponse(sampleResponses.get(1), Duration.ofMillis(10));
+    GetFeaturesResponse getFeaturesResponseEquals =
+        new GetFeaturesResponse(sampleResponses.get(1), Duration.ofMillis(5));
+    GetFeaturesResponse getFeaturesResponseNotEquals =
+        new GetFeaturesResponse(sampleResponses.get(2), Duration.ofMillis(10));
+
+    Assert.assertEquals(getFeaturesResponse, getFeaturesResponseEquals);
+    Assert.assertEquals(getFeaturesResponse.hashCode(), getFeaturesResponseEquals.hashCode());
+    Assert.assertNotEquals(getFeaturesResponse, getFeaturesResponseNotEquals);
+    Assert.assertNotEquals(getFeaturesResponse.hashCode(), getFeaturesResponseNotEquals.hashCode());
+  }
+
   private void checkFeatureValues(Map<String, FeatureValue> featureValues) {
     Assert.assertEquals(5, getFeaturesResponse.getFeatureValues().size());
     Assert.assertEquals(


### PR DESCRIPTION
## Description

1. Add `equals()` and `hashCode()` methods to public Request and Response classes
2. Add Builders for all public classes
3. Add Javadoc for Builder methods
4. Add unit tests for testing `equals()` and `hashCode()` 

## Related Issues
1. https://github.com/tecton-ai/tecton-http-client-java/issues/47
2. https://github.com/tecton-ai/tecton-http-client-java/issues/48