### PR TITLE
Fix Effective Time Parsing

### DIFF
--- a/src/main/java/ai/tecton/client/model/FeatureValue.java
+++ b/src/main/java/ai/tecton/client/model/FeatureValue.java
@@ -2,8 +2,8 @@ package ai.tecton.client.model;
 
 import ai.tecton.client.exceptions.TectonClientException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.*;
 import org.apache.commons.lang3.StringUtils;
 
@@ -12,8 +12,6 @@ import org.apache.commons.lang3.StringUtils;
  * GetFeaturesResponse
  */
 public class FeatureValue {
-  private final SimpleDateFormat dateFormat =
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
 
   private final String featureNamespace;
   private final String featureName;
@@ -38,8 +36,7 @@ public class FeatureValue {
     // Parse effective_time if present
     try {
       if (StringUtils.isNotEmpty(effectiveTime)) {
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        this.effectiveTime = dateFormat.parse(effectiveTime).toInstant();
+        this.effectiveTime = OffsetDateTime.parse(effectiveTime).toInstant();
       }
     } catch (Exception e) {
       throw new TectonClientException(TectonErrorMessage.UNKNOWN_DATETIME_FORMAT);

--- a/src/main/java/ai/tecton/client/model/ListDataType.java
+++ b/src/main/java/ai/tecton/client/model/ListDataType.java
@@ -5,6 +5,7 @@ import ai.tecton.client.exceptions.TectonErrorMessage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("unchecked")
 class ListDataType {
@@ -21,8 +22,14 @@ class ListDataType {
     // Parse List of Object to List of corresponding Java type
     switch (listElementType) {
       case INT64:
-        this.int64List = new ArrayList<>(featureObjectList.size());
-        featureObjectList.forEach(obj -> this.int64List.add(Long.parseLong((String) obj)));
+        this.int64List =
+            featureObjectList.stream()
+                .map(
+                    obj -> {
+                      String stringValue = (String) obj;
+                      return (stringValue != null) ? Long.parseLong(stringValue) : null;
+                    })
+                .collect(Collectors.toList());
         break;
       case FLOAT32:
         this.float32List = new ArrayList<>(featureObjectList.size());

--- a/src/test/java/ai/tecton/client/model/FeatureValueTest.java
+++ b/src/test/java/ai/tecton/client/model/FeatureValueTest.java
@@ -132,6 +132,44 @@ public class FeatureValueTest {
   }
 
   @Test
+  public void testLongListWithNulls() {
+    List<Long> expectedArray =
+        new ArrayList<Long>() {
+          {
+            add(123L);
+            add(335L);
+            add(null);
+            add(null);
+          }
+        };
+
+    // The response from Tecton API will represent an array of Int64 values as an array of String
+    List<String> arrayInput =
+        new ArrayList<String>() {
+          {
+            add("123");
+            add("335");
+            add(null);
+            add(null);
+          }
+        };
+
+    FeatureValue featureValue =
+        new FeatureValue(
+            arrayInput,
+            testName,
+            ValueType.ARRAY,
+            Optional.of(ValueType.INT64),
+            null,
+            Optional.of(FeatureStatus.PRESENT));
+
+    Assert.assertEquals(ValueType.ARRAY, featureValue.getValueType());
+    Assert.assertEquals(ValueType.INT64, featureValue.getListElementType().get());
+    List<Long> actualArray = featureValue.int64ArrayValue();
+    Assert.assertEquals(expectedArray, actualArray);
+  }
+
+  @Test
   public void testInvalidTypeAccess() {
     FeatureValue featureValue =
         new FeatureValue(

--- a/src/test/resources/mocktest/getfeatures/sampleFeatureResponse1.json
+++ b/src/test/resources/mocktest/getfeatures/sampleFeatureResponse1.json
@@ -124,7 +124,7 @@
       },
       {
         "name": "user_transaction_counts.transaction_count_90d_1d",
-        "effectiveTime": "2022-07-06T00:00:00Z",
+        "effectiveTime": "2023-06-13T03:20:46.563Z",
         "dataType": {
           "type": "int64"
         },


### PR DESCRIPTION

## Description

1. Our effective_time parsing was expecting a very specific DateTime format. Instead we can use OffsetDateTime to account for different formats.
2. Account for null values when parsing an array of Int64 values returned as Strings from Tecton API

## Related Issues
1. https://github.com/tecton-ai/tecton-http-client-java/issues/58
2. https://github.com/tecton-ai/tecton-http-client-java/issues/57