### PR TITLE
Add InvalidRequestParameterException

### DIFF
--- a/src/main/java/ai/tecton/client/exceptions/InvalidRequestParameterException.java
+++ b/src/main/java/ai/tecton/client/exceptions/InvalidRequestParameterException.java
@@ -1,0 +1,13 @@
+package ai.tecton.client.exceptions;
+
+/**
+ * An exception class representing a client error caused by a misconfigured request, such as missing
+ * workspace name, missing feature service name etc. It extends the {@link TectonClientException}
+ * class.
+ */
+public class InvalidRequestParameterException extends TectonClientException {
+
+  public InvalidRequestParameterException(final String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/src/main/java/ai/tecton/client/request/AbstractGetFeaturesRequest.java
+++ b/src/main/java/ai/tecton/client/request/AbstractGetFeaturesRequest.java
@@ -2,7 +2,7 @@ package ai.tecton.client.request;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import ai.tecton.client.exceptions.TectonClientException;
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.model.MetadataOption;
 import ai.tecton.client.transport.TectonHttpClient.HttpMethod;
@@ -30,7 +30,7 @@ public abstract class AbstractGetFeaturesRequest extends AbstractTectonRequest {
       String featureServiceName,
       String endpoint,
       Set<MetadataOption> metadataOptions)
-      throws TectonClientException {
+      throws InvalidRequestParameterException {
     super(endpoint, httpMethod, workspaceName, featureServiceName);
     if (metadataOptions == null || metadataOptions.size() == 0) {
       this.metadataOptions = RequestConstants.DEFAULT_METADATA_OPTIONS;
@@ -61,7 +61,7 @@ public abstract class AbstractGetFeaturesRequest extends AbstractTectonRequest {
   static void validateRequestParameters(GetFeaturesRequestData getFeaturesRequestData) {
     if (getFeaturesRequestData.isEmptyJoinKeyMap()
         && getFeaturesRequestData.isEmptyRequestContextMap()) {
-      throw new TectonClientException(TectonErrorMessage.EMPTY_REQUEST_MAPS);
+      throw new InvalidRequestParameterException(TectonErrorMessage.EMPTY_REQUEST_MAPS);
     }
   }
 

--- a/src/main/java/ai/tecton/client/request/AbstractTectonRequest.java
+++ b/src/main/java/ai/tecton/client/request/AbstractTectonRequest.java
@@ -1,5 +1,6 @@
 package ai.tecton.client.request;
 
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonClientException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.transport.TectonHttpClient;
@@ -67,7 +68,7 @@ public abstract class AbstractTectonRequest {
       Validate.notEmpty(workspaceName, TectonErrorMessage.INVALID_WORKSPACENAME);
       Validate.notEmpty(featureServiceName, TectonErrorMessage.INVALID_FEATURESERVICENAME);
     } catch (Exception e) {
-      throw new TectonClientException(e.getMessage());
+      throw new InvalidRequestParameterException(e.getMessage());
     }
   }
 

--- a/src/main/java/ai/tecton/client/request/GetFeatureServiceMetadataRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeatureServiceMetadataRequest.java
@@ -1,6 +1,6 @@
 package ai.tecton.client.request;
 
-import ai.tecton.client.exceptions.TectonClientException;
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.transport.TectonHttpClient;
 import com.squareup.moshi.JsonAdapter;
@@ -71,7 +71,7 @@ public class GetFeatureServiceMetadataRequest extends AbstractTectonRequest {
     try {
       return jsonAdapter.toJson(new GetFeatureServiceMetadataJson(serviceMetadataFields));
     } catch (Exception e) {
-      throw new TectonClientException(
+      throw new InvalidRequestParameterException(
           String.format(TectonErrorMessage.INVALID_GET_SERVICE_METADATA_REQUEST, e.getMessage()));
     }
   }
@@ -111,7 +111,8 @@ public class GetFeatureServiceMetadataRequest extends AbstractTectonRequest {
      * Returns an instance of {@link GetFeatureServiceMetadataRequest}
      *
      * @return {@link GetFeatureServiceMetadataRequest} object
-     * @throws TectonClientException when workspaceName and/or featureServiceName is null or empty
+     * @throws InvalidRequestParameterException when workspaceName and/or featureServiceName is null
+     *     or empty
      */
     public GetFeatureServiceMetadataRequest build() {
       return new GetFeatureServiceMetadataRequest(featureServiceName, workspaceName);

--- a/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
@@ -1,5 +1,6 @@
 package ai.tecton.client.request;
 
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonClientException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.model.MetadataOption;
@@ -66,9 +67,10 @@ public class GetFeaturesBatchRequest {
    *     requested
    * @param requestDataList a {@link List} of {@link GetFeaturesRequestData} object with joinKeyMap
    *     and/or requestContextMap
-   * @throws TectonClientException when workspacename or featureServiceName is empty or null
-   * @throws TectonClientException when requestDataList is invalid (null/empty or contains
-   *     null/empty elements)
+   * @throws InvalidRequestParameterException when workspacename or featureServiceName is empty or
+   *     null
+   * @throws InvalidRequestParameterException when requestDataList is invalid (null/empty or
+   *     contains null/empty elements)
    */
   public GetFeaturesBatchRequest(
       String workspaceName,
@@ -98,9 +100,10 @@ public class GetFeaturesBatchRequest {
    *     request all metadata and {@link RequestConstants#NONE_METADATA_OPTIONS} to request no
    *     metadata respectively. By default, {@link RequestConstants#DEFAULT_METADATA_OPTIONS} will
    *     be added to each request
-   * @throws TectonClientException when workspaceName or featureServiceName is empty or null
-   * @throws TectonClientException when requestDataList is invalid (null/empty or contains
-   *     null/empty elements)
+   * @throws InvalidRequestParameterException when workspaceName or featureServiceName is empty or
+   *     null
+   * @throws InvalidRequestParameterException when requestDataList is invalid (null/empty or
+   *     contains null/empty elements)
    */
   public GetFeaturesBatchRequest(
       String workspaceName,
@@ -134,9 +137,10 @@ public class GetFeaturesBatchRequest {
    *     RequestConstants#MAX_MICRO_BATCH_SIZE}. The client splits the GetFeaturesBatchRequest into
    *     multiple micro batches of this size and executes them parallely. By default, the
    *     microBatchSize is set to {@value RequestConstants#DEFAULT_MICRO_BATCH_SIZE}
-   * @throws TectonClientException when workspaceName or featureServiceName is empty or null
-   * @throws TectonClientException when requestDataList is invalid (null/empty or contains
-   *     null/empty elements)
+   * @throws InvalidRequestParameterException when workspaceName or featureServiceName is empty or
+   *     null
+   * @throws InvalidRequestParameterException when requestDataList is invalid (null/empty or
+   *     contains null/empty elements)
    */
   public GetFeaturesBatchRequest(
       String workspaceName,
@@ -173,11 +177,12 @@ public class GetFeaturesBatchRequest {
    * @param timeout The max time in {@link Duration} for which the client waits for the batch
    *     requests to complete before canceling the operation and returning the partial list of
    *     results.
-   * @throws TectonClientException when workspacename or featureServiceName is empty or null
-   * @throws TectonClientException when requestDataList is invalid (null/empty or contains
-   *     null/empty elements)
-   * @throws TectonClientException when the microBatchSize is out of bounds of [ 1, {@value
-   *     RequestConstants#MAX_MICRO_BATCH_SIZE} ]
+   * @throws InvalidRequestParameterException when workspaceName or featureServiceName is empty or
+   *     null
+   * @throws InvalidRequestParameterException when requestDataList is invalid (null/empty or
+   *     contains null/empty elements)
+   * @throws InvalidRequestParameterException when the microBatchSize is out of bounds of [ 1,
+   *     {@value RequestConstants#MAX_MICRO_BATCH_SIZE} ]
    */
   public GetFeaturesBatchRequest(
       String workspaceName,
@@ -345,8 +350,8 @@ public class GetFeaturesBatchRequest {
      *     into multiple micro batches of this size and executes them parallely. By default, the
      *     microBatchSize is set to {@value RequestConstants#DEFAULT_MICRO_BATCH_SIZE}
      * @return this Builder
-     * @throws TectonClientException when the microBatchSize is out of bounds of [ 1, {@value
-     *     RequestConstants#MAX_MICRO_BATCH_SIZE} ]
+     * @throws InvalidRequestParameterException when the microBatchSize is out of bounds of [ 1,
+     *     {@value RequestConstants#MAX_MICRO_BATCH_SIZE} ]
      */
     public Builder microBatchSize(int microBatchSize) throws TectonClientException {
       this.microBatchSize = microBatchSize;
@@ -371,7 +376,7 @@ public class GetFeaturesBatchRequest {
      * @return {@link GetFeaturesBatchRequest} object
      * @throws TectonClientException when requestDataList is invalid ( when the requestDataList is
      *     null or empty, or any joinKeyMap or requestContextMap is null or empty)
-     * @throws TectonClientException when microBatchSize is out of bounds of [1, {@value
+     * @throws InvalidRequestParameterException when microBatchSize is out of bounds of [1, {@value
      *     RequestConstants#MAX_MICRO_BATCH_SIZE}
      */
     public GetFeaturesBatchRequest build() throws TectonClientException {
@@ -393,11 +398,11 @@ public class GetFeaturesBatchRequest {
       int microBatchSize) {
     AbstractTectonRequest.validateRequestParameters(workspaceName, featureServiceName);
     if (requestDataList == null || requestDataList.isEmpty()) {
-      throw new TectonClientException(TectonErrorMessage.INVALID_REQUEST_DATA_LIST);
+      throw new InvalidRequestParameterException(TectonErrorMessage.INVALID_REQUEST_DATA_LIST);
     }
     requestDataList.parallelStream().forEach(AbstractGetFeaturesRequest::validateRequestParameters);
     if (microBatchSize > RequestConstants.MAX_MICRO_BATCH_SIZE || microBatchSize < 1) {
-      throw new TectonClientException(
+      throw new InvalidRequestParameterException(
           String.format(
               TectonErrorMessage.INVALID_MICRO_BATCH_SIZE,
               1,
@@ -472,7 +477,7 @@ public class GetFeaturesBatchRequest {
       try {
         return jsonAdapter.toJson(getFeaturesRequestJson);
       } catch (Exception e) {
-        throw new TectonClientException(
+        throw new InvalidRequestParameterException(
             String.format(TectonErrorMessage.INVALID_GET_FEATURE_BATCH_REQUEST, e.getMessage()));
       }
     }

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
@@ -1,6 +1,6 @@
 package ai.tecton.client.request;
 
-import ai.tecton.client.exceptions.TectonClientException;
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.model.MetadataOption;
 import com.squareup.moshi.JsonAdapter;
@@ -114,7 +114,7 @@ public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
     try {
       return jsonAdapter.toJson(getFeaturesRequestJson);
     } catch (Exception e) {
-      throw new TectonClientException(
+      throw new InvalidRequestParameterException(
           String.format(TectonErrorMessage.INVALID_GET_FEATURE_REQUEST, e.getMessage()));
     }
   }
@@ -204,7 +204,8 @@ public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
      * Returns an instance of {@link GetFeaturesRequest} created from the fields set on this builder
      *
      * @return {@link GetFeaturesRequest} object
-     * @throws TectonClientException when workspaceName and/or featureServiceName is null or empty
+     * @throws InvalidRequestParameterException when workspaceName and/or featureServiceName is null
+     *     or empty
      */
     public GetFeaturesRequest build() {
       if (this.metadataOptions.isEmpty()) {

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
@@ -1,6 +1,6 @@
 package ai.tecton.client.request;
 
-import ai.tecton.client.exceptions.TectonClientException;
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,11 +33,11 @@ public class GetFeaturesRequestData {
    *     <p>For int64 (Long) keys, the value should be a string of the decimal representation of the
    *     integer
    * @return Returns the GetFeaturesRequestData object after setting joinKeyMap
-   * @throws TectonClientException when joinKeyMap is null or empty, or any key or value in the map
-   *     is null or empty
+   * @throws InvalidRequestParameterException when joinKeyMap is null or empty, or any key or value
+   *     in the map is null or empty
    */
   public GetFeaturesRequestData addJoinKeyMap(Map<String, String> joinKeyMap)
-      throws TectonClientException {
+      throws InvalidRequestParameterException {
     Validate.notEmpty(joinKeyMap);
     joinKeyMap.forEach(this::validateKeyValue);
     this.joinKeyMap = joinKeyMap;
@@ -55,11 +55,11 @@ public class GetFeaturesRequestData {
    *     of the integer
    *     <p>For double values, the value should be a java.lang.Double
    * @return Returns the GetFeaturesRequestData object after setting requestContextMap
-   * @throws TectonClientException when requestContextMap is null or empty, or any key or value in
-   *     the map is null or empty
+   * @throws InvalidRequestParameterException when requestContextMap is null or empty, or any key or
+   *     value in the map is null or empty
    */
   public GetFeaturesRequestData addRequestContextMap(Map<String, Object> requestContextMap)
-      throws TectonClientException {
+      throws InvalidRequestParameterException {
     Validate.notEmpty(requestContextMap);
     requestContextMap.forEach(this::validateKeyValueDisallowingNullValue);
     this.requestContextMap = requestContextMap;
@@ -72,9 +72,10 @@ public class GetFeaturesRequestData {
    * @param key join key name
    * @param value String join value
    * @return Returns the GetFeaturesRequestData object after adding the join key value
-   * @throws TectonClientException when the join key or value is null or empty
+   * @throws InvalidRequestParameterException when the join key or value is null or empty
    */
-  public GetFeaturesRequestData addJoinKey(String key, String value) throws TectonClientException {
+  public GetFeaturesRequestData addJoinKey(String key, String value)
+      throws InvalidRequestParameterException {
     validateKeyValue(key, value);
     joinKeyMap.put(key, value);
     return this;
@@ -86,9 +87,10 @@ public class GetFeaturesRequestData {
    * @param key join key name
    * @param value int64 (Long) join value
    * @return Returns the GetFeaturesRequestData object after adding the join key value
-   * @throws TectonClientException when the join key or value is null or empty
+   * @throws InvalidRequestParameterException when the join key or value is null or empty
    */
-  public GetFeaturesRequestData addJoinKey(String key, Long value) throws TectonClientException {
+  public GetFeaturesRequestData addJoinKey(String key, Long value)
+      throws InvalidRequestParameterException {
     String joinKeyValue = (value == null) ? null : value.toString();
     validateKeyValue(key, joinKeyValue);
     joinKeyMap.put(key, joinKeyValue);
@@ -101,10 +103,10 @@ public class GetFeaturesRequestData {
    * @param key request context name
    * @param value String request context value
    * @return Returns the GetFeaturesRequestData object after adding the request context key value
-   * @throws TectonClientException when the request context key or value is null or empty
+   * @throws InvalidRequestParameterException when the request context key or value is null or empty
    */
   public GetFeaturesRequestData addRequestContext(String key, String value)
-      throws TectonClientException {
+      throws InvalidRequestParameterException {
     validateKeyValueDisallowingNullValue(key, value);
     requestContextMap.put(key, value);
     return this;
@@ -118,10 +120,10 @@ public class GetFeaturesRequestData {
    *     <p>Note: The int64 value is converted to a String of the decimal representation of the
    *     integer
    * @return Returns the GetFeaturesRequestData object after adding the request context key value
-   * @throws TectonClientException when the request context key or value is null or empty
+   * @throws InvalidRequestParameterException when the request context key or value is null or empty
    */
   public GetFeaturesRequestData addRequestContext(String key, Long value)
-      throws TectonClientException {
+      throws InvalidRequestParameterException {
     validateKeyValueDisallowingNullValue(key, value);
     requestContextMap.put(key, value.toString());
     return this;
@@ -133,10 +135,10 @@ public class GetFeaturesRequestData {
    * @param key request context name
    * @param value Double request context value
    * @return Returns the GetFeaturesRequestData object after adding the request context key value
-   * @throws TectonClientException when the request context key or value is null or empty
+   * @throws InvalidRequestParameterException when the request context key or value is null or empty
    */
   public GetFeaturesRequestData addRequestContext(String key, Double value)
-      throws TectonClientException {
+      throws InvalidRequestParameterException {
     validateKeyValueDisallowingNullValue(key, value);
     requestContextMap.put(key, value);
     return this;
@@ -159,15 +161,23 @@ public class GetFeaturesRequestData {
   }
 
   private void validateKeyValue(String key, Object value) {
-    Validate.notEmpty(key, TectonErrorMessage.INVALID_KEY_VALUE);
-    if (value instanceof String) {
-      Validate.notEmpty((String) value, TectonErrorMessage.INVALID_KEY_VALUE);
+    try {
+      Validate.notEmpty(key, TectonErrorMessage.INVALID_KEY_VALUE);
+      if (value instanceof String) {
+        Validate.notEmpty((String) value, TectonErrorMessage.INVALID_KEY_VALUE);
+      }
+    } catch (Exception e) {
+      throw new InvalidRequestParameterException(e.getMessage());
     }
   }
 
   private void validateKeyValueDisallowingNullValue(String key, Object value) {
-    validateKeyValue(key, value);
-    Validate.notNull(value, TectonErrorMessage.INVALID_KEY_VALUE);
+    try {
+      validateKeyValue(key, value);
+      Validate.notNull(value, TectonErrorMessage.INVALID_KEY_VALUE);
+    } catch (Exception e) {
+      throw new InvalidRequestParameterException(e.getMessage());
+    }
   }
 
   /** A Builder class for creating an instance of {@link GetFeaturesRequestData} object */

--- a/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
@@ -2,6 +2,7 @@ package ai.tecton.client.request;
 
 import static org.junit.Assert.fail;
 
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +24,7 @@ public class GetFeatureRequestDataTest {
     try {
       getFeaturesRequestData.addJoinKey(null, "testValue");
       fail();
-    } catch (NullPointerException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }
@@ -32,7 +33,7 @@ public class GetFeatureRequestDataTest {
   public void testShouldAllowNullJoinValue() {
     try {
       getFeaturesRequestData.addJoinKey("testKey", (String) null);
-    } catch (NullPointerException e) {
+    } catch (InvalidRequestParameterException e) {
       fail();
     }
   }
@@ -42,7 +43,7 @@ public class GetFeatureRequestDataTest {
     try {
       getFeaturesRequestData.addRequestContext(null, "testValue");
       fail();
-    } catch (NullPointerException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }
@@ -52,7 +53,7 @@ public class GetFeatureRequestDataTest {
     try {
       getFeaturesRequestData.addRequestContext("testKey", (String) null);
       fail();
-    } catch (NullPointerException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }
@@ -62,7 +63,7 @@ public class GetFeatureRequestDataTest {
     try {
       getFeaturesRequestData.addJoinKey("", "testValue");
       fail();
-    } catch (IllegalArgumentException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }
@@ -72,7 +73,7 @@ public class GetFeatureRequestDataTest {
     try {
       getFeaturesRequestData.addJoinKey("testKey", "");
       fail();
-    } catch (IllegalArgumentException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }
@@ -82,7 +83,7 @@ public class GetFeatureRequestDataTest {
     try {
       getFeaturesRequestData.addRequestContext("", "testValue");
       fail();
-    } catch (IllegalArgumentException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }
@@ -92,7 +93,7 @@ public class GetFeatureRequestDataTest {
     try {
       getFeaturesRequestData.addRequestContext("testKey", "");
       fail();
-    } catch (IllegalArgumentException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }

--- a/src/test/java/ai/tecton/client/request/GetFeaturesBatchRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesBatchRequestTest.java
@@ -3,6 +3,7 @@ package ai.tecton.client.request;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonClientException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.model.MetadataOption;
@@ -107,7 +108,7 @@ public class GetFeaturesBatchRequestTest {
               .requestDataList(requestData)
               .build();
       fail();
-    } catch (IllegalArgumentException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }

--- a/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
@@ -2,7 +2,7 @@ package ai.tecton.client.request;
 
 import static org.junit.Assert.fail;
 
-import ai.tecton.client.exceptions.TectonClientException;
+import ai.tecton.client.exceptions.InvalidRequestParameterException;
 import ai.tecton.client.exceptions.TectonErrorMessage;
 import ai.tecton.client.model.MetadataOption;
 import ai.tecton.client.transport.TectonHttpClient;
@@ -37,7 +37,7 @@ public class GetFeaturesRequestTest {
       getFeaturesRequest =
           new GetFeaturesRequest("", TEST_FEATURESERVICE_NAME, defaultFeatureRequestData);
       fail();
-    } catch (TectonClientException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_WORKSPACENAME, e.getMessage());
     }
   }
@@ -48,7 +48,7 @@ public class GetFeaturesRequestTest {
       getFeaturesRequest =
           new GetFeaturesRequest(TEST_WORKSPACENAME, "", defaultFeatureRequestData);
       fail();
-    } catch (TectonClientException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_FEATURESERVICENAME, e.getMessage());
     }
   }
@@ -59,7 +59,7 @@ public class GetFeaturesRequestTest {
       getFeaturesRequest =
           new GetFeaturesRequest(null, TEST_FEATURESERVICE_NAME, defaultFeatureRequestData);
       fail();
-    } catch (TectonClientException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_WORKSPACENAME, e.getMessage());
     }
   }
@@ -70,7 +70,7 @@ public class GetFeaturesRequestTest {
       getFeaturesRequest =
           new GetFeaturesRequest(TEST_WORKSPACENAME, null, defaultFeatureRequestData);
       fail();
-    } catch (TectonClientException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.INVALID_FEATURESERVICENAME, e.getMessage());
     }
   }
@@ -83,7 +83,7 @@ public class GetFeaturesRequestTest {
           new GetFeaturesRequest(
               TEST_WORKSPACENAME, TEST_FEATURESERVICE_NAME, getFeaturesRequestData);
       fail();
-    } catch (TectonClientException e) {
+    } catch (InvalidRequestParameterException e) {
       Assert.assertEquals(TectonErrorMessage.EMPTY_REQUEST_MAPS, e.getMessage());
     }
   }


### PR DESCRIPTION
Throw InvalidRequestParameterException when the request is misconfigured.  TectonClientException will only be thrown for unexpected cases such as misformatted response, missing expected information in the response etc