### PR TITLE
Allow null Request Context values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.6.0-SNAPSHOT
+version=0.7.0-SNAPSHOT
 ossrh.username=tecton-team

--- a/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesBatchRequest.java
@@ -67,7 +67,7 @@ public class GetFeaturesBatchRequest {
    *     requested
    * @param requestDataList a {@link List} of {@link GetFeaturesRequestData} object with joinKeyMap
    *     and/or requestContextMap
-   * @throws InvalidRequestParameterException when workspacename or featureServiceName is empty or
+   * @throws InvalidRequestParameterException when workspaceName or featureServiceName is empty or
    *     null
    * @throws InvalidRequestParameterException when requestDataList is invalid (null/empty or
    *     contains null/empty elements)

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequest.java
@@ -85,7 +85,7 @@ public class GetFeaturesRequest extends AbstractGetFeaturesRequest {
     String feature_service_name;
     String workspace_name;
     @SerializeNulls Map<String, String> join_key_map;
-    Map<String, Object> request_context_map;
+    @SerializeNulls Map<String, Object> request_context_map;
     Map<String, Boolean> metadata_options;
   }
 

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
@@ -33,8 +33,8 @@ public class GetFeaturesRequestData {
    *     <p>For int64 (Long) keys, the value should be a string of the decimal representation of the
    *     integer
    * @return Returns the GetFeaturesRequestData object after setting joinKeyMap
-   * @throws InvalidRequestParameterException when joinKeyMap is null or empty, or any key or value
-   *     in the map is null or empty
+   * @throws InvalidRequestParameterException when joinKeyMap is null or empty, or any key in the
+   *     map is null or empty
    */
   public GetFeaturesRequestData addJoinKeyMap(Map<String, String> joinKeyMap)
       throws InvalidRequestParameterException {
@@ -55,13 +55,13 @@ public class GetFeaturesRequestData {
    *     of the integer
    *     <p>For double values, the value should be a java.lang.Double
    * @return Returns the GetFeaturesRequestData object after setting requestContextMap
-   * @throws InvalidRequestParameterException when requestContextMap is null or empty, or any key or
-   *     value in the map is null or empty
+   * @throws InvalidRequestParameterException when requestContextMap is null or empty, or any key in
+   *     the map is null or empty
    */
   public GetFeaturesRequestData addRequestContextMap(Map<String, Object> requestContextMap)
       throws InvalidRequestParameterException {
     Validate.notEmpty(requestContextMap);
-    requestContextMap.forEach(this::validateKeyValueDisallowingNullValue);
+    requestContextMap.forEach(this::validateKeyValue);
     this.requestContextMap = requestContextMap;
     return this;
   }
@@ -72,7 +72,7 @@ public class GetFeaturesRequestData {
    * @param key join key name
    * @param value String join value
    * @return Returns the GetFeaturesRequestData object after adding the join key value
-   * @throws InvalidRequestParameterException when the join key or value is null or empty
+   * @throws InvalidRequestParameterException when the join key is null or empty
    */
   public GetFeaturesRequestData addJoinKey(String key, String value)
       throws InvalidRequestParameterException {
@@ -87,7 +87,7 @@ public class GetFeaturesRequestData {
    * @param key join key name
    * @param value int64 (Long) join value
    * @return Returns the GetFeaturesRequestData object after adding the join key value
-   * @throws InvalidRequestParameterException when the join key or value is null or empty
+   * @throws InvalidRequestParameterException when the join key is null or empty
    */
   public GetFeaturesRequestData addJoinKey(String key, Long value)
       throws InvalidRequestParameterException {
@@ -103,11 +103,11 @@ public class GetFeaturesRequestData {
    * @param key request context name
    * @param value String request context value
    * @return Returns the GetFeaturesRequestData object after adding the request context key value
-   * @throws InvalidRequestParameterException when the request context key or value is null or empty
+   * @throws InvalidRequestParameterException when the request context key is null or empty
    */
   public GetFeaturesRequestData addRequestContext(String key, String value)
       throws InvalidRequestParameterException {
-    validateKeyValueDisallowingNullValue(key, value);
+    validateKeyValue(key, value);
     requestContextMap.put(key, value);
     return this;
   }
@@ -120,11 +120,11 @@ public class GetFeaturesRequestData {
    *     <p>Note: The int64 value is converted to a String of the decimal representation of the
    *     integer
    * @return Returns the GetFeaturesRequestData object after adding the request context key value
-   * @throws InvalidRequestParameterException when the request context key or value is null or empty
+   * @throws InvalidRequestParameterException when the request context key is null or empty
    */
   public GetFeaturesRequestData addRequestContext(String key, Long value)
       throws InvalidRequestParameterException {
-    validateKeyValueDisallowingNullValue(key, value);
+    validateKeyValue(key, value);
     requestContextMap.put(key, value.toString());
     return this;
   }
@@ -135,11 +135,11 @@ public class GetFeaturesRequestData {
    * @param key request context name
    * @param value Double request context value
    * @return Returns the GetFeaturesRequestData object after adding the request context key value
-   * @throws InvalidRequestParameterException when the request context key or value is null or empty
+   * @throws InvalidRequestParameterException when the request context key is null or empty
    */
   public GetFeaturesRequestData addRequestContext(String key, Double value)
       throws InvalidRequestParameterException {
-    validateKeyValueDisallowingNullValue(key, value);
+    validateKeyValue(key, value);
     requestContextMap.put(key, value);
     return this;
   }
@@ -166,15 +166,6 @@ public class GetFeaturesRequestData {
       if (value instanceof String) {
         Validate.notEmpty((String) value, TectonErrorMessage.INVALID_KEY_VALUE);
       }
-    } catch (Exception e) {
-      throw new InvalidRequestParameterException(e.getMessage());
-    }
-  }
-
-  private void validateKeyValueDisallowingNullValue(String key, Object value) {
-    try {
-      validateKeyValue(key, value);
-      Validate.notNull(value, TectonErrorMessage.INVALID_KEY_VALUE);
     } catch (Exception e) {
       throw new InvalidRequestParameterException(e.getMessage());
     }

--- a/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
@@ -49,12 +49,11 @@ public class GetFeatureRequestDataTest {
   }
 
   @Test
-  public void testNullRequestContextValue() {
+  public void testShouldAllowNullRequestContextValue() {
     try {
       getFeaturesRequestData.addRequestContext("testKey", (String) null);
+    } catch (Exception e) {
       fail();
-    } catch (InvalidRequestParameterException e) {
-      Assert.assertEquals(TectonErrorMessage.INVALID_KEY_VALUE, e.getMessage());
     }
   }
 

--- a/src/test/java/ai/tecton/client/request/GetFeaturesBatchRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesBatchRequestTest.java
@@ -327,7 +327,7 @@ public class GetFeaturesBatchRequestTest {
 
     String actual = getFeaturesBatchRequest.getRequestList().get(0).requestToJson();
     String expected =
-        "{\"params\":{\"feature_service_name\":\"testFSName\",\"join_key_map\":{\"testNullKey\":null},\"metadata_options\":{\"include_names\":true,\"include_data_types\":true},\"workspace_name\":\"testWorkspaceName\"}}";
+        "{\"params\":{\"feature_service_name\":\"testFSName\",\"join_key_map\":{\"testNullKey\":null},\"metadata_options\":{\"include_names\":true,\"include_data_types\":true},\"request_context_map\":null,\"workspace_name\":\"testWorkspaceName\"}}";
     Assert.assertEquals(expected, actual);
   }
 

--- a/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
@@ -106,7 +106,7 @@ public class GetFeaturesRequestTest {
     Assert.assertEquals("testValue", joinKeyMap.get("testKey"));
 
     String expected_json =
-        "{\"params\":{\"feature_service_name\":\"testFSName\",\"join_key_map\":{\"testKey\":\"testValue\"},\"metadata_options\":{\"include_names\":true,\"include_data_types\":true},\"workspace_name\":\"testWorkspaceName\"}}";
+        "{\"params\":{\"feature_service_name\":\"testFSName\",\"join_key_map\":{\"testKey\":\"testValue\"},\"metadata_options\":{\"include_names\":true,\"include_data_types\":true},\"request_context_map\":null,\"workspace_name\":\"testWorkspaceName\"}}";
     String actual_json = getFeaturesRequest.requestToJson();
 
     Assert.assertEquals(expected_json, actual_json);
@@ -131,7 +131,7 @@ public class GetFeaturesRequestTest {
     Assert.assertEquals("testValue", joinKeyMap.get("testKey"));
 
     String expected_json =
-        "{\"params\":{\"feature_service_name\":\"testFSName\",\"join_key_map\":{\"testNullKey\":null,\"testKey\":\"testValue\"},\"metadata_options\":{\"include_names\":true,\"include_data_types\":true},\"workspace_name\":\"testWorkspaceName\"}}";
+        "{\"params\":{\"feature_service_name\":\"testFSName\",\"join_key_map\":{\"testNullKey\":null,\"testKey\":\"testValue\"},\"metadata_options\":{\"include_names\":true,\"include_data_types\":true},\"request_context_map\":null,\"workspace_name\":\"testWorkspaceName\"}}";
     String actual_json = getFeaturesRequest.requestToJson();
 
     Assert.assertEquals(expected_json, actual_json);

--- a/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesRequestTest.java
@@ -141,6 +141,7 @@ public class GetFeaturesRequestTest {
   public void testRequestWithRequestContextMap() throws IOException {
     defaultFeatureRequestData.addRequestContext("testKey1", 999.999);
     defaultFeatureRequestData.addRequestContext("testKey2", "testVal");
+    defaultFeatureRequestData.addRequestContext("testNullKey", (String) null);
 
     getFeaturesRequest =
         new GetFeaturesRequest(
@@ -153,12 +154,13 @@ public class GetFeaturesRequestTest {
 
     Map<String, Object> requestContextMap =
         getFeaturesRequest.getFeaturesRequestData().getRequestContextMap();
-    Assert.assertEquals(2, requestContextMap.size());
+    Assert.assertEquals(3, requestContextMap.size());
     Assert.assertEquals(999.999, requestContextMap.get("testKey1"));
     Assert.assertEquals("testVal", requestContextMap.get("testKey2"));
+    Assert.assertNull(requestContextMap.get("testNullKey"));
 
     String expected_json =
-        "{\"params\":{\"feature_service_name\":\"testFSName\",\"join_key_map\":{\"testKey\":\"testValue\"},\"metadata_options\":{\"include_names\":true,\"include_data_types\":true},\"request_context_map\":{\"testKey2\":\"testVal\",\"testKey1\":999.999},\"workspace_name\":\"testWorkspaceName\"}}";
+        "{\"params\":{\"feature_service_name\":\"testFSName\",\"join_key_map\":{\"testKey\":\"testValue\"},\"metadata_options\":{\"include_names\":true,\"include_data_types\":true},\"request_context_map\":{\"testKey2\":\"testVal\",\"testNullKey\":null,\"testKey1\":999.999},\"workspace_name\":\"testWorkspaceName\"}}";
     String actual_json = getFeaturesRequest.requestToJson();
 
     Assert.assertEquals(expected_json, actual_json);


### PR DESCRIPTION
Allow users to pass in null as values to `requestContextMap`. This should be safe as long as the user code handles null values in the ODFV