### PR TITLE
Handle Long null values

### DIFF
--- a/src/main/java/ai/tecton/client/exceptions/TectonErrorMessage.java
+++ b/src/main/java/ai/tecton/client/exceptions/TectonErrorMessage.java
@@ -7,7 +7,7 @@ package ai.tecton.client.exceptions;
 public class TectonErrorMessage {
   public static final String INVALID_KEY = "API Key cannot be empty";
   public static final String INVALID_URL = "Cannot connect to Tecton because the URL is invalid";
-  public static final String INVALID_KEY_VALUE = "Key/Value cannot be null or empty";
+  public static final String INVALID_KEY_VALUE = "Key cannot be null or empty.";
 
   public static final String CALL_FAILURE = "Unable to perform call. %s";
   public static final String ERROR_RESPONSE =

--- a/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
+++ b/src/main/java/ai/tecton/client/request/GetFeaturesRequestData.java
@@ -125,7 +125,8 @@ public class GetFeaturesRequestData {
   public GetFeaturesRequestData addRequestContext(String key, Long value)
       throws InvalidRequestParameterException {
     validateKeyValue(key, value);
-    requestContextMap.put(key, value.toString());
+    String requestContextValue = (value == null) ? null : value.toString();
+    requestContextMap.put(key, requestContextValue);
     return this;
   }
 

--- a/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeatureRequestDataTest.java
@@ -51,7 +51,11 @@ public class GetFeatureRequestDataTest {
   @Test
   public void testShouldAllowNullRequestContextValue() {
     try {
-      getFeaturesRequestData.addRequestContext("testKey", (String) null);
+      getFeaturesRequestData.addRequestContext("testStringKey", (String) null);
+      getFeaturesRequestData.addRequestContext("testLongKey", (Long) null);
+      getFeaturesRequestData.addRequestContext("testDoubleKey", (Double) null);
+
+      Assert.assertEquals(3, getFeaturesRequestData.getRequestContextMap().size());
     } catch (Exception e) {
       fail();
     }


### PR DESCRIPTION
Handle Request Context values that are null for Long type. Long types are converted to strings in the JSON request sent.