### PR TITLE
Update java client to use addPathSegments to fix encoding issue

### DIFF
--- a/src/main/java/ai/tecton/client/transport/HttpRequest.java
+++ b/src/main/java/ai/tecton/client/transport/HttpRequest.java
@@ -19,7 +19,7 @@ class HttpRequest {
     if (endpoint != null && !endpoint.isEmpty()) {
       // Paths with leading backslash results in a URL with double backslash.
       // See https://github.com/square/okhttp/issues/2399#issuecomment-195354749
-      url = url.newBuilder().addPathSegment(StringUtils.stripStart(endpoint, "/")).build();
+      url = url.newBuilder().addPathSegments(StringUtils.stripStart(endpoint, "/")).build();
     }
     this.method = method;
     this.apiKey = apiKey;

--- a/src/test/java/ai/tecton/client/transport/TectonHttpClientTest.java
+++ b/src/test/java/ai/tecton/client/transport/TectonHttpClientTest.java
@@ -88,6 +88,8 @@ public class TectonHttpClientTest {
     Assert.assertEquals(
         "Tecton-key " + apiKey,
         request.headers().get(TectonHttpClient.HttpHeader.AUTHORIZATION.getName()));
+    Assert.assertEquals(
+        "http://test-url.com/api/v1/feature-service/get-features", request.url().toString());
   }
 
   @Test


### PR DESCRIPTION
Changes the way paths are encoded for use by the Java client to correctly encode forward slashes.

Updates a test to check the endpoint URL is as expected.

Also tested by importing the locally built JAR file into the tecton-http-client-demo project and running the E2E tests internally.