### PR TITLE
Make okhttp an API dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,24 +36,18 @@ In the demo client [repository](https://github.com/tecton-ai/TectonClientDemo) u
 jar that you generate from this repo using `./gradlew clean build`.
 
 1. Change the dependencies target to this and point the files attribute to your java client jar.
-2. Add all dependencies from `tecton-http-client-java` except `testImplementation` to `build.gradle` in the demo client repository.
+2. Add the okhttp3 dependency from `tecton-http-client-java` to `build.gradle` in the demo client repository. This is
+   necessary because it is an API dependency, but JAR files don't include information about transitive dependencies.
+   Published libraries on Maven don't have this issue.
 
 ```
 dependencies {
     implementation files('libs/java-client-0.1.0-SNAPSHOT.jar')
-    implementation 'com.google.code.gson:gson:2.2.4'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
-    testImplementation 'junit:junit:4.13.2'
     // OkHttp Client
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0'
-    // Moshi JSON Parsing Library
-    implementation group: 'com.squareup.moshi', name: 'moshi', version: '1.13.0'
-    // Moshi JSON Adapter Library for Standard Java Types
-    implementation group: 'com.squareup.moshi', name: 'moshi-adapters', version: '1.13.0'
     // StringUtils and Validation checks
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
-    // Collection operations such as Partition and Parallel Streams
-    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+    testImplementation 'junit:junit:4.13.2'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
-    id 'java'
+    id 'java-library'
     id 'maven-publish'
     id 'signing'
 }
@@ -16,23 +16,24 @@ repositories {
 sourceCompatibility = 8
 targetCompatibility = 8
 
-//Project dependencies
+// Project dependencies
 dependencies {
-    //OkHttp Client
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0'
-    //Moshi JSON Parsing Library
+    // OkHttp Client included as an API dependency because it is present in the public API of this library.
+    api group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.10.0'
+
+    // Moshi JSON Parsing Library
     implementation group: 'com.squareup.moshi', name: 'moshi', version: '1.13.0'
-    //Moshi JSON Adapter Library for Standard Java Types
+    // Moshi JSON Adapter Library for Standard Java Types
     implementation group: 'com.squareup.moshi', name: 'moshi-adapters', version: '1.13.0'
-    //StringUtils and Validation checks
+    // StringUtils and Validation checks
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
-    //Collection operations such as Partition and Parallel Streams
+    // Collection operations such as Partition and Parallel Streams
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-    //JUnit tests
+    // JUnit tests
     testImplementation 'junit:junit:4.13.2'
-    //Mock Server for OkHttp Testing
+    // Mock Server for OkHttp Testing
     testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
-    //Mockito for mock tests
+    // Mockito for mock tests
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.3.1'
 }
 
@@ -58,7 +59,7 @@ sourceSets.main.java.srcDir "$buildDir/generated-src/ai.tecton.client.version"
 
 compileJava.dependsOn generateVersionFile
 
-//Run tests during build and output status
+// Run tests during build and output status
 test {
     useJUnit()
     testLogging {
@@ -71,7 +72,6 @@ test {
         showExceptions = true
         showCauses = true
         showStackTraces = true
-
     }
 }
 
@@ -91,7 +91,7 @@ artifacts {
     archives javadocJar
 }
 
-//Publish JAR to Nexus
+// Publish JAR to Nexus
 publishing {
     repositories {
         maven {
@@ -132,7 +132,6 @@ publishing {
                         email = 'plateng-rss-team@tecton.ai'
                         organization = 'Tecton'
                         organizationUrl = 'https://www.tecton.ai/'
-
                     }
                 }
 


### PR DESCRIPTION
Change okhttp to an api dependency from just an implementation dependency.

Since okhttp3 types are used in our public API (constructor parameters), users of the library otherwise need to depend on okhttp3 themselves, even if they don't actually use that part of the API.