### PR TITLE
Set maxRequests for OkHttp dispatcher to maxParallelRequests

### DIFF
--- a/src/main/java/ai/tecton/client/transport/TectonHttpClient.java
+++ b/src/main/java/ai/tecton/client/transport/TectonHttpClient.java
@@ -55,6 +55,7 @@ public class TectonHttpClient {
     this.apiKey = apiKey;
     Dispatcher dispatcher = new Dispatcher();
     dispatcher.setMaxRequestsPerHost(tectonClientOptions.getMaxParallelRequests());
+    dispatcher.setMaxRequests(tectonClientOptions.getMaxParallelRequests());
 
     OkHttpClient.Builder builder =
         new OkHttpClient.Builder()


### PR DESCRIPTION
This is effectively the same as maxRequestsPerHost, since the host for an instantiated TectonClient is always the same. Fixes a bug where the user-specified maxParallelRequests is greater than the default of 64 maxRequests, and so doesn't take effect.