### PR TITLE
Add ability to set RequestOptions

### DIFF
--- a/src/main/java/ai/tecton/client/request/RequestOptions.java
+++ b/src/main/java/ai/tecton/client/request/RequestOptions.java
@@ -1,0 +1,140 @@
+package ai.tecton.client.request;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Class that represents request-level options to control feature server behavior. These options are
+ * sent as part of the requestOptions field in GetFeatures and GetFeaturesBatch requests. Option
+ * values must be either Integer or Boolean.
+ */
+public class RequestOptions {
+
+  private Map<String, Object> options;
+
+  /** Constructor that creates a new RequestOptions object with default empty options */
+  public RequestOptions() {
+    this.options = new HashMap<>();
+  }
+
+  /**
+   * Sets a request option with the given key and value.
+   *
+   * @param key the option key
+   * @param value the option value (must be either Integer or Boolean)
+   * @return Returns the RequestOptions object for method chaining
+   * @throws IllegalArgumentException if value is not Integer or Boolean
+   */
+  public RequestOptions setOption(String key, Object value) {
+    if (value != null && !(value instanceof Integer) && !(value instanceof Boolean)) {
+      throw new IllegalArgumentException(
+          "Option value must be either Integer or Boolean, got: "
+              + value.getClass().getSimpleName());
+    }
+    this.options.put(key, value);
+    return this;
+  }
+
+  /**
+   * Gets a specific option value by key.
+   *
+   * @param key the option key
+   * @return the option value, or null if not set
+   */
+  public Object getOption(String key) {
+    return this.options.get(key);
+  }
+
+  /**
+   * Gets a specific option value by key as an Integer.
+   *
+   * @param key the option key
+   * @return the option value as Integer, or null if not set or not an Integer
+   */
+  public Integer getIntegerOption(String key) {
+    Object value = this.options.get(key);
+    return value instanceof Integer ? (Integer) value : null;
+  }
+
+  /**
+   * Gets a specific option value by key as a Boolean.
+   *
+   * @param key the option key
+   * @return the option value as Boolean, or null if not set or not a Boolean
+   */
+  public Boolean getBooleanOption(String key) {
+    Object value = this.options.get(key);
+    return value instanceof Boolean ? (Boolean) value : null;
+  }
+
+  /**
+   * Gets all options as an unmodifiable map.
+   *
+   * @return Map containing all request options
+   */
+  public Map<String, Object> getOptions() {
+    return new HashMap<>(this.options);
+  }
+
+  /**
+   * Checks if any options are set.
+   *
+   * @return true if no options are set, false otherwise
+   */
+  public boolean isEmpty() {
+    return this.options.isEmpty();
+  }
+
+  /** A Builder class for creating an instance of {@link RequestOptions} object */
+  public static class Builder {
+    private RequestOptions requestOptions;
+
+    /** Instantiates a new Builder */
+    public Builder() {
+      requestOptions = new RequestOptions();
+    }
+
+    /**
+     * Sets a request option with the given key and value.
+     *
+     * @param key the option key
+     * @param value the option value (must be either Integer or Boolean)
+     * @return this Builder
+     * @throws IllegalArgumentException if value is not Integer or Boolean
+     */
+    public Builder option(String key, Object value) {
+      requestOptions.setOption(key, value);
+      return this;
+    }
+
+    /**
+     * Build a {@link RequestOptions} object from the Builder
+     *
+     * @return {@link RequestOptions}
+     */
+    public RequestOptions build() {
+      return this.requestOptions;
+    }
+  }
+
+  /** Overrides <i>equals()</i> in class {@link Object} */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    RequestOptions that = (RequestOptions) o;
+    return Objects.equals(options, that.options);
+  }
+
+  /** Overrides <i>hashCode()</i> in class {@link Object} */
+  @Override
+  public int hashCode() {
+    return Objects.hash(options);
+  }
+
+  @Override
+  public String toString() {
+    return "RequestOptions{" + "options=" + options + '}';
+  }
+}

--- a/src/test/java/ai/tecton/client/request/GetFeaturesRequestWithOptionsTest.java
+++ b/src/test/java/ai/tecton/client/request/GetFeaturesRequestWithOptionsTest.java
@@ -1,0 +1,99 @@
+package ai.tecton.client.request;
+
+import static org.junit.Assert.*;
+
+import ai.tecton.client.model.MetadataOption;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+public class GetFeaturesRequestWithOptionsTest {
+
+  @Test
+  public void testGetFeaturesRequestWithRequestOptions() {
+    // Create request data
+    GetFeaturesRequestData requestData =
+        new GetFeaturesRequestData.Builder()
+            .joinKeyMap(java.util.Collections.singletonMap("testKey", "testValue"))
+            .requestContextMap(java.util.Collections.singletonMap("testKey", "testValue"))
+            .build();
+
+    // Create request options
+    RequestOptions requestOptions =
+        new RequestOptions.Builder()
+            .option("latency_budget_ms", 5000)
+            .option("coerceNullCountsToZero", true)
+            .option("readFromCache", false)
+            .option("writeFromCache", true)
+            .option("ignoreExtraRequestContextFields", false)
+            .build();
+
+    // Create request with options
+    Set<MetadataOption> metadataOptions = new HashSet<>();
+    metadataOptions.add(MetadataOption.NAME);
+    metadataOptions.add(MetadataOption.DATA_TYPE);
+
+    GetFeaturesRequest request =
+        new GetFeaturesRequest(
+            "testWorkspaceName", "testFSName", requestData, metadataOptions, requestOptions);
+
+    // Verify JSON contains request_options with all expected values
+    String json = request.requestToJson();
+    assertTrue(json.contains("request_options"));
+    assertTrue(json.contains("\"latency_budget_ms\":5000"));
+    assertTrue(json.contains("\"coerceNullCountsToZero\":true"));
+    assertTrue(json.contains("\"readFromCache\":false"));
+    assertTrue(json.contains("\"writeFromCache\":true"));
+    assertTrue(json.contains("\"ignoreExtraRequestContextFields\":false"));
+  }
+
+  @Test
+  public void testGetFeaturesRequestBuilderWithRequestOptions() {
+    // Create request data
+    GetFeaturesRequestData requestData =
+        new GetFeaturesRequestData.Builder()
+            .joinKeyMap(java.util.Collections.singletonMap("testKey", "testValue"))
+            .build();
+
+    // Create request options
+    RequestOptions requestOptions =
+        new RequestOptions.Builder()
+            .option("latency_budget_ms", 3000)
+            .option("coerceNullCountsToZero", false)
+            .option("readFromCache", true)
+            .build();
+
+    // Use the builder to create request with options
+    GetFeaturesRequest request =
+        new GetFeaturesRequest.Builder()
+            .workspaceName("testWorkspaceName")
+            .featureServiceName("testFSName")
+            .getFeaturesRequestData(requestData)
+            .requestOptions(requestOptions)
+            .build();
+
+    // Verify JSON contains request_options with expected structure
+    String json = request.requestToJson();
+    assertTrue(json.contains("request_options"));
+    assertTrue(json.contains("\"latency_budget_ms\":3000"));
+    assertTrue(json.contains("\"coerceNullCountsToZero\":false"));
+    assertTrue(json.contains("\"readFromCache\":true"));
+  }
+
+  @Test
+  public void testGetFeaturesRequestWithoutRequestOptions() {
+    // Create request data
+    GetFeaturesRequestData requestData =
+        new GetFeaturesRequestData.Builder()
+            .joinKeyMap(java.util.Collections.singletonMap("testKey", "testValue"))
+            .build();
+
+    // Create request without options
+    GetFeaturesRequest request =
+        new GetFeaturesRequest("testWorkspaceName", "testFSName", requestData);
+
+    // Verify JSON does not contain request_options
+    String json = request.requestToJson();
+    assertFalse(json.contains("request_options"));
+  }
+}

--- a/src/test/java/ai/tecton/client/request/RequestOptionsTest.java
+++ b/src/test/java/ai/tecton/client/request/RequestOptionsTest.java
@@ -1,0 +1,94 @@
+package ai.tecton.client.request;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class RequestOptionsTest {
+
+  @Test
+  public void testRequestOptionsCreation() {
+    RequestOptions options = new RequestOptions();
+    assertTrue(options.isEmpty());
+  }
+
+  @Test
+  public void testIntegerOptionSetting() {
+    RequestOptions options = new RequestOptions();
+    options.setOption("latency_budget_ms", 1000);
+
+    assertEquals(Integer.valueOf(1000), options.getIntegerOption("latency_budget_ms"));
+    assertEquals(Integer.valueOf(1000), options.getOption("latency_budget_ms"));
+    assertFalse(options.isEmpty());
+    assertEquals(1, options.getOptions().size());
+  }
+
+  @Test
+  public void testBooleanOptionSetting() {
+    RequestOptions options = new RequestOptions();
+    options.setOption("coerceNullCountsToZero", true);
+
+    assertEquals(Boolean.TRUE, options.getBooleanOption("coerceNullCountsToZero"));
+    assertEquals(Boolean.TRUE, options.getOption("coerceNullCountsToZero"));
+    assertFalse(options.isEmpty());
+  }
+
+  @Test
+  public void testMultipleBooleanOptions() {
+    RequestOptions options = new RequestOptions();
+    options.setOption("readFromCache", true);
+    options.setOption("writeFromCache", false);
+    options.setOption("ignoreExtraRequestContextFields", true);
+
+    assertEquals(Boolean.TRUE, options.getBooleanOption("readFromCache"));
+    assertEquals(Boolean.FALSE, options.getBooleanOption("writeFromCache"));
+    assertEquals(Boolean.TRUE, options.getBooleanOption("ignoreExtraRequestContextFields"));
+    assertEquals(3, options.getOptions().size());
+  }
+
+  @Test
+  public void testMixedIntegerAndBooleanOptions() {
+    RequestOptions options = new RequestOptions();
+    options.setOption("latency_budget_ms", 5000);
+    options.setOption("coerceNullCountsToZero", false);
+
+    assertEquals(Integer.valueOf(5000), options.getIntegerOption("latency_budget_ms"));
+    assertEquals(Boolean.FALSE, options.getBooleanOption("coerceNullCountsToZero"));
+    assertEquals(2, options.getOptions().size());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidValueTypeThrowsException() {
+    RequestOptions options = new RequestOptions();
+    options.setOption("invalid_option", "string_value");
+  }
+
+  @Test
+  public void testBuilder() {
+    RequestOptions options =
+        new RequestOptions.Builder()
+            .option("latency_budget_ms", 2000)
+            .option("readFromCache", true)
+            .option("writeFromCache", false)
+            .build();
+
+    assertEquals(Integer.valueOf(2000), options.getIntegerOption("latency_budget_ms"));
+    assertEquals(Boolean.TRUE, options.getBooleanOption("readFromCache"));
+    assertEquals(Boolean.FALSE, options.getBooleanOption("writeFromCache"));
+    assertEquals(3, options.getOptions().size());
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    RequestOptions options1 = new RequestOptions();
+    options1.setOption("latency_budget_ms", 1000);
+    options1.setOption("readFromCache", true);
+
+    RequestOptions options2 = new RequestOptions();
+    options2.setOption("latency_budget_ms", 1000);
+    options2.setOption("readFromCache", true);
+
+    assertEquals(options1, options2);
+    assertEquals(options1.hashCode(), options2.hashCode());
+  }
+}


### PR DESCRIPTION
Adds a RequestOptions class and builder that allows users to set arbitrary request options int he client. These will be rejected by the server if the request option doesn't exist.