### PR TITLE
Update java-build job name

### DIFF
--- a/.github/workflows/java-build.yml
+++ b/.github/workflows/java-build.yml
@@ -8,7 +8,7 @@ on:
       - main
       - release
 jobs:
-  java-gradle-build:
+  java-maven-build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Updates the name since we're using Maven instead of Gradle now.

I've updated the repo sitting in the GH web UI so that PR merges to main look for a completed workflow with the new string rather than the old string.